### PR TITLE
[#69] upstream changes

### DIFF
--- a/src/integration/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionRunner_IntegrationTest.java
+++ b/src/integration/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionRunner_IntegrationTest.java
@@ -3,26 +3,18 @@ package nz.cri.gns.NZSHM22.opensha.inversion;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_LogicTreeBranch;
-import cern.colt.matrix.tdouble.DoubleMatrix2D;
-import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_SpatialSeisPDF;
 import org.dom4j.DocumentException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.opensha.commons.data.CSVFile;
-import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionInputGenerator;
 import org.opensha.sha.earthquake.faultSysSolution.modules.ClusterRuptures;
-import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
 
 public class NZSHM22_InversionRunner_IntegrationTest {
 
@@ -65,13 +57,13 @@ public class NZSHM22_InversionRunner_IntegrationTest {
     @Test(expected = IllegalArgumentException.class)
     public void testSetSlipRateConstraintThrowsWithInvalidArgument() {
         NZSHM22_CrustalInversionRunner runner = (NZSHM22_CrustalInversionRunner) new NZSHM22_CrustalInversionRunner()
-                .setSlipRateConstraint(SlipRateConstraintWeightingType.UNCERTAINTY_ADJUSTED, 1, 2);
+                .setSlipRateConstraint(AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.NORMALIZED_BY_UNCERTAINTY, 1, 2);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testSetSlipRateUncertaintyConstraintThrowsWithInvalidArgument() {
         NZSHM22_CrustalInversionRunner runner = new NZSHM22_CrustalInversionRunner()
-                .setSlipRateUncertaintyConstraint(SlipRateConstraintWeightingType.BOTH, 1, 2);
+                .setSlipRateUncertaintyConstraint(AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.BOTH, 1, 2);
     }
 
 }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionConfiguration.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionConfiguration.java
@@ -3,19 +3,8 @@ package nz.cri.gns.NZSHM22.opensha.inversion;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.cli.CommandLine;
-import org.dom4j.Element;
-import org.opensha.commons.metadata.XMLSaveable;
-import org.opensha.commons.util.XMLUtils;
-import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.magdist.IncrementalMagFreqDist;
-import org.opensha.sha.magdist.SummedMagFreqDist;
-
-import com.google.common.collect.Lists;
-
 import scratch.UCERF3.enumTreeBranches.InversionModels;
-import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
-import scratch.UCERF3.utils.MFD_InversionConstraint;
 
 /**
  * This represents all of the inversion configuration parameters specific to an
@@ -29,8 +18,6 @@ import scratch.UCERF3.utils.MFD_InversionConstraint;
 public class NZSHM22_CrustalInversionConfiguration extends AbstractInversionConfiguration {
 
 	protected final static boolean D = true; // for debugging
-
-	private String metadata;
 
 	/**
 	 * 
@@ -120,7 +107,7 @@ public class NZSHM22_CrustalInversionConfiguration extends AbstractInversionConf
 		// since it helps fit slow-moving faults). If unnormalized, misfit is absolute
 		// difference.
 		// BOTH includes both normalized and unnormalized constraints.
-		SlipRateConstraintWeightingType slipRateWeighting = SlipRateConstraintWeightingType.BOTH; // (recommended: BOTH)
+		NZSlipRateConstraintWeightingType slipRateWeighting = NZSlipRateConstraintWeightingType.BOTH; // (recommended: BOTH)
 
 		// weight of rupture-rate minimization constraint weights relative to slip-rate
 		// constraint (recommended: 10,000)
@@ -140,7 +127,7 @@ public class NZSHM22_CrustalInversionConfiguration extends AbstractInversionConf
 		NZSHM22_CrustalInversionTargetMFDs inversionMFDs = new NZSHM22_CrustalInversionTargetMFDs(rupSet,
 				totalRateM5_Sans, totalRateM5_TVZ, bValue_Sans, bValue_TVZ, mMin_Sans, mMin_TVZ);
 		rupSet.setInversionTargetMFDs(inversionMFDs);
-		List<MFD_InversionConstraint> mfdConstraints = inversionMFDs.getMFD_Constraints();
+		List<IncrementalMagFreqDist> mfdConstraints = inversionMFDs.getMFD_Constraints();
 
 		if (model.isConstrained()) {
 			// CONSTRAINED BRANCHES
@@ -163,17 +150,17 @@ public class NZSHM22_CrustalInversionConfiguration extends AbstractInversionConf
 
 		/* end MODIFIERS */
 
-		List<MFD_InversionConstraint> mfdInequalityConstraints = new ArrayList<MFD_InversionConstraint>();
-		List<MFD_InversionConstraint> mfdEqualityConstraints = new ArrayList<MFD_InversionConstraint>();
+		List<IncrementalMagFreqDist> mfdInequalityConstraints = new ArrayList<>();
+		List<IncrementalMagFreqDist> mfdEqualityConstraints = new ArrayList<>();
 
 		if (mfdEqualityConstraintWt > 0.0 && mfdInequalityConstraintWt > 0.0) {
 			// we have both MFD constraints, apply a transition mag from equality to
 			// inequality
 
 			mfdEqualityConstraints = restrictMFDConstraintMagRange(mfdConstraints,
-					mfdConstraints.get(0).getMagFreqDist().getMinX(), mfdTransitionMag);
+					mfdConstraints.get(0).getMinX(), mfdTransitionMag);
 			mfdInequalityConstraints = restrictMFDConstraintMagRange(mfdConstraints, mfdTransitionMag,
-					mfdConstraints.get(0).getMagFreqDist().getMaxX());
+					mfdConstraints.get(0).getMaxX());
 		} else if (mfdEqualityConstraintWt > 0.0) {
 			mfdEqualityConstraints = mfdConstraints;
 		} else if (mfdInequalityConstraintWt > 0.0) {
@@ -200,10 +187,6 @@ public class NZSHM22_CrustalInversionConfiguration extends AbstractInversionConf
 				.setMinimumRuptureRateBasis(minimumRuptureRateBasis).setInitialRupModel(initialRupModel);
 
 		return newConfig;
-	}
-
-	public String getMetadata() {
-		return metadata;
 	}
 
 }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionInputGenerator.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionInputGenerator.java
@@ -2,61 +2,24 @@ package nz.cri.gns.NZSHM22.opensha.inversion;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-//import org.opensha.commons.eq.MagUtils;
-//import org.opensha.commons.util.IDPairing;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionInputGenerator;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.ConstraintWeightingType;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.APrioriInversionConstraint;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.MFDEqualityInversionConstraint;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.MFDInequalityInversionConstraint;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.MFDSubSectNuclInversionConstraint;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.RupRateMinimizationConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.MFDLaplacianSmoothingInversionConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.MFDParticipationSmoothnessInversionConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.MFDSubSectNuclInversionConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.PaleoRateInversionConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.PaleoSlipInversionConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.PaleoVisibleEventRateSmoothnessInversionConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.ParkfieldInversionConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.RupRateMinimizationConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.RupRateSmoothingInversionConstraint;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.SlipRateInversionConstraint;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.SlipRateUncertaintyInversionConstraint;
-//import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.TotalMomentInversionConstraint;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.*;
 import org.opensha.sha.faultSurface.FaultSection;
-//import org.opensha.sha.magdist.IncrementalMagFreqDist;
 
 import com.google.common.base.Preconditions;
-//import com.google.common.base.Stopwatch;
-//import com.google.common.collect.Lists;
-//import com.google.common.collect.Maps;
 
 import nz.cri.gns.NZSHM22.opensha.analysis.NZSHM22_FaultSystemRupSetCalc;
-//import cern.colt.function.tdouble.IntIntDoubleFunction;
-//import cern.colt.list.tdouble.DoubleArrayList;
-//import cern.colt.list.tint.IntArrayList;
-//import cern.colt.matrix.tdouble.DoubleMatrix2D;
 
-import scratch.UCERF3.SlipEnabledRupSet;
-import scratch.UCERF3.utils.SectionMFD_constraint;
-//import scratch.UCERF3.analysis.FaultSystemRupSetCalc;
-//import scratch.UCERF3.enumTreeBranches.InversionModels;
-//
-//import scratch.UCERF3.logicTree.LogicTreeBranch;
-//import scratch.UCERF3.simulatedAnnealing.ConstraintRange;
-//import scratch.UCERF3.utils.MFD_InversionConstraint;
-//import scratch.UCERF3.utils.SectionMFD_constraint;
-import scratch.UCERF3.utils.aveSlip.AveSlipConstraint;
-import scratch.UCERF3.utils.paleoRateConstraints.PaleoProbabilityModel;
-import scratch.UCERF3.utils.paleoRateConstraints.PaleoRateConstraint;
+import scratch.UCERF3.utils.U3SectionMFD_constraint;
+import scratch.UCERF3.utils.aveSlip.U3AveSlipConstraint;
+import scratch.UCERF3.utils.paleoRateConstraints.U3PaleoRateConstraint;
 import scratch.UCERF3.utils.paleoRateConstraints.UCERF3_PaleoProbabilityModel;
-import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
 
 /**
  * This class is used to generate inversion inputs (A/A_ineq matrices, d/d_ineq
@@ -79,13 +42,13 @@ public class NZSHM22_CrustalInversionInputGenerator extends InversionInputGenera
 	// inputs
 	private NZSHM22_InversionFaultSystemRuptSet rupSet;
 	private AbstractInversionConfiguration config;
-	private List<PaleoRateConstraint> paleoRateConstraints;
-	private List<AveSlipConstraint> aveSlipConstraints;
+	private List<U3PaleoRateConstraint> paleoRateConstraints;
+	private List<U3AveSlipConstraint> aveSlipConstraints;
 	private double[] improbabilityConstraint;
 	private PaleoProbabilityModel paleoProbabilityModel;
 
 	public NZSHM22_CrustalInversionInputGenerator(NZSHM22_InversionFaultSystemRuptSet rupSet, NZSHM22_CrustalInversionConfiguration config,
-			List<PaleoRateConstraint> paleoRateConstraints, List<AveSlipConstraint> aveSlipConstraints,
+			List<U3PaleoRateConstraint> paleoRateConstraints, List<U3AveSlipConstraint> aveSlipConstraints,
 			double[] improbabilityConstraint, // may become an object in the future
 			PaleoProbabilityModel paleoProbabilityModel) {
 		super(rupSet, buildConstraints(rupSet, config, paleoRateConstraints, aveSlipConstraints, paleoProbabilityModel),
@@ -114,14 +77,14 @@ public class NZSHM22_CrustalInversionInputGenerator extends InversionInputGenera
 	}
 
 	private static List<InversionConstraint> buildConstraints(NZSHM22_InversionFaultSystemRuptSet rupSet,
-			NZSHM22_CrustalInversionConfiguration config, List<PaleoRateConstraint> paleoRateConstraints,
-			List<AveSlipConstraint> aveSlipConstraints, PaleoProbabilityModel paleoProbabilityModel) {
+			NZSHM22_CrustalInversionConfiguration config, List<U3PaleoRateConstraint> paleoRateConstraints,
+			List<U3AveSlipConstraint> aveSlipConstraints, PaleoProbabilityModel paleoProbabilityModel) {
 
 		System.out.println("buildConstraints");
 		System.out.println("================");
 		
 		System.out.println("config.getSlipRateWeightingType(): " + config.getSlipRateWeightingType());
-		if (config.getSlipRateWeightingType() == SlipRateConstraintWeightingType.UNCERTAINTY_ADJUSTED) {
+		if (config.getSlipRateWeightingType() == AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.NORMALIZED_BY_UNCERTAINTY) {
 			System.out.println("config.getSlipRateUncertaintyConstraintWt() :" +  config.getSlipRateUncertaintyConstraintWt());
 			System.out.println("config.getSlipRateUncertaintyConstraintScalingFactor() :" +  config.getSlipRateUncertaintyConstraintScalingFactor());
 		} else {
@@ -136,23 +99,29 @@ public class NZSHM22_CrustalInversionInputGenerator extends InversionInputGenera
 		// builds constraint instances
 		List<InversionConstraint> constraints = new ArrayList<>();
 
-		if (config.getSlipRateWeightingType() == SlipRateConstraintWeightingType.UNCERTAINTY_ADJUSTED) {
+		if (config.getSlipRateWeightingType() == AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.NORMALIZED_BY_UNCERTAINTY) {
 			//NZSHM22 new slip-rate constraint
 			double[] sectSlipRateReduced = rupSet.getSlipRateForAllSections();
 			double[] stdDevReduced = rupSet.getSlipRateStdDevForAllSections();
-			constraints.add(new SlipRateUncertaintyInversionConstraint(config.getSlipRateUncertaintyConstraintWt(),
+			constraints.add(new NZ_SlipRateUncertaintyInversionConstraint(config.getSlipRateUncertaintyConstraintWt(),
 					config.getSlipRateUncertaintyConstraintScalingFactor(), rupSet, sectSlipRateReduced, stdDevReduced));
-		} else {
-			//UCERF3 style slip rate constraints...
-			if (config.getSlipRateConstraintWt_normalized() > 0d || config.getSlipRateConstraintWt_unnormalized() > 0d) {
-				// add slip rate constraint
-				double[] sectSlipRateReduced = rupSet.getSlipRateForAllSections();
-				constraints.add(new SlipRateInversionConstraint(config.getSlipRateConstraintWt_normalized(),
-						config.getSlipRateConstraintWt_unnormalized(), config.getSlipRateWeightingType(), rupSet,
-						sectSlipRateReduced));
-			}
 		}
-		
+
+		if (config.getSlipRateConstraintWt_normalized() > 0d
+				&& (config.getSlipRateWeightingType() == AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.NORMALIZED
+				|| config.getSlipRateWeightingType() == AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.BOTH))
+		{
+			constraints.add(new SlipRateInversionConstraint(config.getSlipRateConstraintWt_normalized(), ConstraintWeightingType.NORMALIZED, rupSet));
+		}
+
+		if (config.getSlipRateConstraintWt_unnormalized() > 0d
+				&& (config.getSlipRateWeightingType() == AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.UNNORMALIZED
+				|| config.getSlipRateWeightingType() == AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.BOTH))
+		{
+			constraints.add(new SlipRateInversionConstraint(config.getSlipRateConstraintWt_unnormalized(), ConstraintWeightingType.UNNORMALIZED, rupSet));
+		}
+
+
 //		if (config.getPaleoRateConstraintWt() > 0d)
 //			constraints.add(new PaleoRateInversionConstraint(rupSet, config.getPaleoRateConstraintWt(),
 //					paleoRateConstraints, paleoProbabilityModel));
@@ -189,15 +158,14 @@ public class NZSHM22_CrustalInversionInputGenerator extends InversionInputGenera
 		// This is for equality constraints only -- inequality constraints must be
 		// encoded into the A_ineq matrix instead since they are nonlinear
 		if (config.getMagnitudeEqualityConstraintWt() > 0.0) {
-			HashSet<Integer> excludeRupIndexes = null;
-			constraints.add(new MFDEqualityInversionConstraint(rupSet, config.getMagnitudeEqualityConstraintWt(),
-					config.getMfdEqualityConstraints(), excludeRupIndexes));
+			constraints.add(new MFDInversionConstraint(rupSet, config.getMagnitudeEqualityConstraintWt(), false,
+					config.getMfdEqualityConstraints()));
 		}
 
 		// Prepare MFD Inequality Constraint (not added to A matrix directly since it's
 		// nonlinear)
 		if (config.getMagnitudeInequalityConstraintWt() > 0.0)
-			constraints.add(new MFDInequalityInversionConstraint(rupSet, config.getMagnitudeInequalityConstraintWt(),
+			constraints.add(new MFDInversionConstraint(rupSet, config.getMagnitudeInequalityConstraintWt(), true,
 					config.getMfdInequalityConstraints()));
 
 //		// MFD Smoothness Constraint - Constrain participation MFD to be uniform for each fault subsection
@@ -206,10 +174,10 @@ public class NZSHM22_CrustalInversionInputGenerator extends InversionInputGenera
 //					config.getParticipationSmoothnessConstraintWt(), config.getParticipationConstraintMagBinSize()));
 
 		// MFD Subsection nucleation MFD constraint
-		ArrayList<SectionMFD_constraint> MFDConstraints = null;
+		ArrayList<U3SectionMFD_constraint> MFDConstraints = null;
 		if (config.getNucleationMFDConstraintWt() > 0.0) {
 			MFDConstraints = NZSHM22_FaultSystemRupSetCalc.getCharInversionSectMFD_Constraints(rupSet);
-			constraints.add(new MFDSubSectNuclInversionConstraint(rupSet, config.getNucleationMFDConstraintWt(),
+			constraints.add(new U3MFDSubSectNuclInversionConstraint(rupSet, config.getNucleationMFDConstraintWt(),
 					MFDConstraints));
 		}
 
@@ -343,7 +311,7 @@ public class NZSHM22_CrustalInversionInputGenerator extends InversionInputGenera
 		return config;
 	}
 
-	public List<PaleoRateConstraint> getPaleoRateConstraints() {
+	public List<U3PaleoRateConstraint> getPaleoRateConstraints() {
 		return paleoRateConstraints;
 	}
 

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunner.java
@@ -10,15 +10,11 @@ import com.google.common.base.Preconditions;
 
 import scratch.UCERF3.U3FaultSystemRupSet;
 import scratch.UCERF3.enumTreeBranches.InversionModels;
-import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
-
 import scratch.UCERF3.utils.U3FaultSystemIO;
-import scratch.UCERF3.utils.aveSlip.AveSlipConstraint;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Runs the standard NSHM inversion on a crustal rupture set.
@@ -52,8 +48,8 @@ public class NZSHM22_CrustalInversionRunner extends NZSHM22_AbstractInversionRun
      *                                  this constraint
      */
     public NZSHM22_CrustalInversionRunner setSlipRateUncertaintyConstraint(
-            SlipRateConstraintWeightingType weightingType, int uncertaintyWeight, int scalingFactor) {
-        Preconditions.checkArgument(weightingType == SlipRateConstraintWeightingType.UNCERTAINTY_ADJUSTED,
+            AbstractInversionConfiguration.NZSlipRateConstraintWeightingType weightingType, int uncertaintyWeight, int scalingFactor) {
+        Preconditions.checkArgument(weightingType == AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.NORMALIZED_BY_UNCERTAINTY,
                 "setSlipRateUncertaintyConstraint() using %s is not supported. Use setSlipRateConstraint() instead.",
                 weightingType);
         this.slipRateWeightingType = weightingType;
@@ -72,7 +68,7 @@ public class NZSHM22_CrustalInversionRunner extends NZSHM22_AbstractInversionRun
      */
     public NZSHM22_CrustalInversionRunner setSlipRateUncertaintyConstraint(String weightingType, int uncertaintyWeight,
                                                                            int scalingFactor) {
-        return setSlipRateUncertaintyConstraint(SlipRateConstraintWeightingType.valueOf(weightingType),
+        return setSlipRateUncertaintyConstraint(AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.valueOf(weightingType),
                 uncertaintyWeight, scalingFactor);
     }
 
@@ -144,7 +140,7 @@ public class NZSHM22_CrustalInversionRunner extends NZSHM22_AbstractInversionRun
 
         // set up slip rate config
         inversionConfiguration.setSlipRateWeightingType(this.slipRateWeightingType);
-        if (this.slipRateWeightingType == SlipRateConstraintWeightingType.UNCERTAINTY_ADJUSTED) {
+        if (this.slipRateWeightingType == AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.NORMALIZED_BY_UNCERTAINTY) {
             System.out.println("config for UNCERTAINTY_ADJUSTED " + this.slipRateUncertaintyWeight + ", "
                     + this.slipRateUncertaintyScalingFactor);
             inversionConfiguration.setSlipRateUncertaintyConstraintWt(this.slipRateUncertaintyWeight);
@@ -157,9 +153,8 @@ public class NZSHM22_CrustalInversionRunner extends NZSHM22_AbstractInversionRun
         /*
          * Build inversion inputs
          */
-        List<AveSlipConstraint> aveSlipConstraints = null;
         NZSHM22_CrustalInversionInputGenerator inversionInputGenerator = new NZSHM22_CrustalInversionInputGenerator(
-                rupSet, inversionConfiguration, null, aveSlipConstraints, null, null);
+                rupSet, inversionConfiguration, null, null, null, null);
         setInversionInputGenerator(inversionInputGenerator);
         return this;
     }
@@ -175,10 +170,10 @@ public class NZSHM22_CrustalInversionRunner extends NZSHM22_AbstractInversionRun
 
         File inputDir = new File("./TEST");
         File outputRoot = new File("./TEST");
-        File ruptureSet = new File(inputDir,
+        File ruptureSet = new File(
 //                "C:\\Code\\NZSHM\\nzshm-opensha\\src\\test\\resources\\AlpineVernonInversionSolution.zip");
 //				"RupSet_Cl_FM(CFM_0_9_SANSTVZ_2010)_mnSbS(2)_mnSSPP(2)_mxSSL(0.5)_mxFS(2000)_noInP(T)_slRtP(0.05)_slInL(F)_cfFr(0.75)_cfRN(2)_cfRTh(0.5)_cfRP(0.01)_fvJm(T)_jmPTh(0.001)_cmRkTh(360)_mxJmD(15)_plCn(T)_adMnD(6)_adScFr(0.2).zip");
-        		"RupSet_Cl_FM(CFM_0_9_SANSTVZ_D90)_noInP(T)_slRtP(0.05)_slInL(F)_cfFr(0.75)_cfRN(2)_cfRTh(0.5)_cfRP(0.01)_fvJm(T)_jmPTh(0.001)_cmRkTh(360)_mxJmD(15)_plCn(T)_adMnD(6)_adScFr(0)_bi(F)_stGrSp(2)_coFr(0.5).zip");
+        		"C:\\Users\\volkertj\\Downloads\\RupSet_Cl_FM(CFM_0_9_SANSTVZ_D90)_noInP(T)_slRtP(0.05)_slInL(F)_cfFr(0.75)_cfRN(2)_cfRTh(0.5)_cfRP(0.01)_fvJm(T)_jmPTh(0.001)_cmRkTh(360)_mxJmD(15)_plCn(T)_adMnD(6)_adScFr(0)_bi(F)_stGrSp(2)_coFr(0.5)(5).zip");
         File outputDir = new File(outputRoot, "inversions");
         Preconditions.checkState(outputDir.exists() || outputDir.mkdir());
 
@@ -188,13 +183,13 @@ public class NZSHM22_CrustalInversionRunner extends NZSHM22_AbstractInversionRun
         scaling.setRake(0);
 
         NZSHM22_CrustalInversionRunner runner = ((NZSHM22_CrustalInversionRunner) new NZSHM22_CrustalInversionRunner()
-                .setInversionSeconds(60)
+                .setInversionSeconds(1)
                 .setScalingRelationship(scaling, true)
              //   .setDeformationModel("GEOD_NO_PRIOR_UNISTD_2010_RmlsZTo4NTkuMDM2Z2Rw")
                 .setRuptureSetFile(ruptureSet)
                 .setGutenbergRichterMFDWeights(100.0, 1000.0)
                 .setSlipRateConstraint("BOTH", 1000, 1000))
-                .setSlipRateUncertaintyConstraint("UNCERTAINTY_ADJUSTED", 1000, 2)
+                .setSlipRateUncertaintyConstraint("NORMALIZED_BY_UNCERTAINTY", 1000, 2)
                 .setGutenbergRichterMFD(4.0, 0.81, 0.91, 1.05, 7.85);
 
         FaultSystemSolution solution = runner.runInversion();

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionTargetMFDs.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionTargetMFDs.java
@@ -58,7 +58,7 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
 	RegionalTargetMFDs sansTvz;
 	RegionalTargetMFDs tvz;
 
-	protected List<MFD_InversionConstraint> mfdConstraints;
+	protected List<IncrementalMagFreqDist> mfdConstraints;
 
 	/**
 	 * For NZ reporting only
@@ -75,7 +75,7 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
 	}
 
 	@Override
-    public List<MFD_InversionConstraint> getMFD_Constraints() {
+    public List<IncrementalMagFreqDist> getMFD_Constraints() {
     	return mfdConstraints;
     }
 
@@ -176,13 +176,13 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
 			double fractionSeisOnFault = gridSeisUtils.pdfInPolys();
 
 			double fractionPDFInRegion = spatialSeisPDF.getFractionInRegion(region);
-			
+
 			System.out.println("fractionPDFInRegion: " + fractionPDFInRegion);
 			System.out.println("faultSectionData.size() " + faultSectionData.size());
 			System.out.println("fractionSeisOnFault " + fractionSeisOnFault);
-			
+
 			fractionSeisOnFault /= fractionPDFInRegion;
-			
+
 			System.out.println("normalised fractionSeisOnFault: " + fractionSeisOnFault);
 
 			double onFaultRegionRateMgt5 = totalRateM5 * fractionSeisOnFault;
@@ -222,6 +222,7 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
 			tempTargetOnFaultSupraSeisMFD.subtractIncrementalMagFreqDist(totalSubSeismoOnFaultMFD);
 
 			targetOnFaultSupraSeisMFDs = fillBelowMag(tempTargetOnFaultSupraSeisMFD, minMag,  1.0e-20);
+			targetOnFaultSupraSeisMFDs.setRegion(region);
 
 			if (MFD_STATS) {
 				System.out.println("totalTargetGR_" + suffix + " after setAllButTotMoRate");
@@ -276,8 +277,8 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
 
 		// Build the MFD Constraints for regions
 		mfdConstraints = new ArrayList<>();
-		mfdConstraints.add(new MFD_InversionConstraint(sansTvz.targetOnFaultSupraSeisMFDs, sansTvz.region));
-		mfdConstraints.add(new MFD_InversionConstraint(tvz.targetOnFaultSupraSeisMFDs, tvz.region));
+		mfdConstraints.add(sansTvz.targetOnFaultSupraSeisMFDs);
+		mfdConstraints.add(tvz.targetOnFaultSupraSeisMFDs);
 
 		/*
 		 * TODO CBC the following block sets up base class var required later to save the solution,

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionFaultSystemRuptSet.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionFaultSystemRuptSet.java
@@ -14,7 +14,6 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.faultSurface.FaultSection;
 import scratch.UCERF3.griddedSeismicity.FaultPolyMgr;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSet;
-import scratch.UCERF3.inversion.InversionTargetMFDs;
 import scratch.UCERF3.inversion.U3InversionTargetMFDs;
 import scratch.UCERF3.utils.UCERF3_Observed_MFD_Fetcher;
 

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionFaultSystemSolution.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionFaultSystemSolution.java
@@ -6,12 +6,12 @@ import org.opensha.commons.data.function.DiscretizedFunc;
 import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
-import org.opensha.sha.earthquake.faultSysSolution.modules.SubSeismoOnFaultMFDs;
+import org.opensha.sha.earthquake.faultSysSolution.modules.GridSourceProvider;
 import org.opensha.sha.magdist.ArbIncrementalMagFreqDist;
 import org.opensha.sha.magdist.IncrementalMagFreqDist;
 import org.opensha.sha.magdist.SummedMagFreqDist;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionTargetMFDs;
 
-import scratch.UCERF3.griddedSeismicity.GridSourceProvider;
 import scratch.UCERF3.inversion.*;
 
 import java.awt.geom.Point2D;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/reports/NZSHM22_MFDPlot.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/reports/NZSHM22_MFDPlot.java
@@ -14,14 +14,12 @@ import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.modules.FaultGridAssociations;
+import org.opensha.sha.earthquake.faultSysSolution.modules.GridSourceProvider;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionTargetMFDs;
 import org.opensha.sha.earthquake.faultSysSolution.reports.AbstractRupSetPlot;
-import org.opensha.sha.earthquake.faultSysSolution.reports.AbstractSolutionPlot;
 import org.opensha.sha.earthquake.faultSysSolution.reports.ReportMetadata;
 import org.opensha.sha.magdist.IncrementalMagFreqDist;
 import org.opensha.sha.magdist.SummedMagFreqDist;
-import scratch.UCERF3.griddedSeismicity.GridSourceProvider;
-import scratch.UCERF3.inversion.InversionTargetMFDs;
-import scratch.UCERF3.utils.MFD_InversionConstraint;
 
 import java.awt.*;
 import java.awt.geom.Point2D;
@@ -94,8 +92,8 @@ public class NZSHM22_MFDPlot extends AbstractRupSetPlot {
 				plotNZSHM22_MFDs(plots, (NZSHM22_CrustalInversionTargetMFDs) targetMFDs);
 			}
 			
-			List<? extends MFD_InversionConstraint> constraints = targetMFDs.getMFD_Constraints();
-			for (MFD_InversionConstraint constraint : constraints) {
+			List<? extends IncrementalMagFreqDist> constraints = targetMFDs.getMFD_Constraints();
+			for (IncrementalMagFreqDist constraint : constraints) {
 				Region region = constraint.getRegion();
 				String name;
 				if (region == null || region.getName() == null || region.getName().isBlank()) {
@@ -106,19 +104,19 @@ public class NZSHM22_MFDPlot extends AbstractRupSetPlot {
 				} else {
 					name = region.getName();
 				}
-				if (constraint.getMagFreqDist().equals(targetMFDs.getTotalOnFaultSupraSeisMFD())) {
+				if (constraint.equals(targetMFDs.getTotalOnFaultSupraSeisMFD())) {
 					// skip it, but set region if applicable
 					totalPlot.region = region;
 				} else {
 					MFD_Plot plot = new MFD_Plot(name, region);
-					plot.addComp(constraint.getMagFreqDist(), SUPRA_SEIS_TARGET_COLOR, "Target");
+					plot.addComp(constraint, SUPRA_SEIS_TARGET_COLOR, "Target");
 					plots.add(plot);
 				}
 				// make sure to include the whole constraint in the plot
-				for (Point2D pt : constraint.getMagFreqDist())
+				for (Point2D pt : constraint)
 					if (pt.getY() > 1e-10)
 						minY = Math.min(minY, Math.pow(10, Math.floor(Math.log10(pt.getY())+0.1)));
-				for (Point2D pt : constraint.getMagFreqDist().getCumRateDistWithOffset())
+				for (Point2D pt : constraint.getCumRateDistWithOffset())
 					maxY = Math.max(maxY, Math.pow(10, Math.ceil(Math.log10(pt.getY())-0.1)));
 			}
 		} else {

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/scripts/FullPipelineCrustal.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/scripts/FullPipelineCrustal.java
@@ -2,63 +2,34 @@ package nz.cri.gns.NZSHM22.opensha.scripts;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.concurrent.Callable;
-
-import javax.swing.text.DateFormatter;
-
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_LogicTreeBranch;
 import nz.cri.gns.NZSHM22.opensha.inversion.*;
-import org.opensha.commons.logicTree.LogicTreeBranch;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.RuptureSets;
 import org.opensha.sha.earthquake.faultSysSolution.RuptureSets.CoulombRupSetConfig;
-import org.opensha.sha.earthquake.faultSysSolution.RuptureSets.RupSetConfig;
-import org.opensha.sha.earthquake.faultSysSolution.modules.FaultGridAssociations;
 import org.opensha.sha.earthquake.faultSysSolution.modules.InitialSolution;
-import org.opensha.sha.earthquake.faultSysSolution.modules.SubSeismoOnFaultMFDs;
 import org.opensha.sha.earthquake.faultSysSolution.modules.WaterLevelRates;
 import org.opensha.sha.earthquake.faultSysSolution.reports.ReportMetadata;
 import org.opensha.sha.earthquake.faultSysSolution.reports.ReportPageGen;
 import org.opensha.sha.earthquake.faultSysSolution.reports.ReportPageGen.PlotLevel;
 import org.opensha.sha.earthquake.faultSysSolution.reports.RupSetMetadata;
-import org.opensha.sha.magdist.IncrementalMagFreqDist;
 
 import com.google.common.base.Preconditions;
 
-import scratch.UCERF3.U3FaultSystemRupSet;
 import scratch.UCERF3.enumTreeBranches.FaultModels;
 import scratch.UCERF3.enumTreeBranches.InversionModels;
-import scratch.UCERF3.enumTreeBranches.MaxMagOffFault;
-import scratch.UCERF3.enumTreeBranches.MomentRateFixes;
 import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
-import scratch.UCERF3.enumTreeBranches.SlipAlongRuptureModels;
-import scratch.UCERF3.enumTreeBranches.SpatialSeisPDF;
-import scratch.UCERF3.griddedSeismicity.UCERF3_GridSourceGenerator;
-import scratch.UCERF3.inversion.CommandLineInversionRunner;
-import scratch.UCERF3.inversion.InversionTargetMFDs;
-import scratch.UCERF3.inversion.UCERF3InversionConfiguration;
-import scratch.UCERF3.inversion.UCERF3InversionInputGenerator;
-import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
-import scratch.UCERF3.logicTree.U3LogicTreeBranch;
-import scratch.UCERF3.simulatedAnnealing.SerialSimulatedAnnealing;
-import scratch.UCERF3.simulatedAnnealing.SimulatedAnnealing;
-import scratch.UCERF3.simulatedAnnealing.ThreadedSimulatedAnnealing;
-import scratch.UCERF3.simulatedAnnealing.completion.CompletionCriteria;
-import scratch.UCERF3.simulatedAnnealing.completion.ProgressTrackingCompletionCriteria;
-import scratch.UCERF3.simulatedAnnealing.completion.TimeCompletionCriteria;
-import scratch.UCERF3.simulatedAnnealing.params.GenerationFunctionType;
-import scratch.UCERF3.simulatedAnnealing.params.NonnegativityConstraintType;
-import scratch.UCERF3.utils.U3FaultSystemIO;
-import scratch.UCERF3.utils.aveSlip.AveSlipConstraint;
-import scratch.UCERF3.utils.paleoRateConstraints.PaleoProbabilityModel;
-import scratch.UCERF3.utils.paleoRateConstraints.PaleoRateConstraint;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.SerialSimulatedAnnealing;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.SimulatedAnnealing;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ThreadedSimulatedAnnealing;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.CompletionCriteria;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.ProgressTrackingCompletionCriteria;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.TimeCompletionCriteria;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.GenerationFunctionType;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.NonnegativityConstraintType;
 
 class FullPipelineCrustal {
 
@@ -76,12 +47,12 @@ class FullPipelineCrustal {
 		String dirName = "2021_08_23";
 		
 		String newName = "Crustal test, like SW52ZXJzaW9uU29sdXRpb246NjEwMC41UlhaTm8= ";
-		SerialSimulatedAnnealing.exp_orders_of_mag = 10;
-		String minScaleStr = new DecimalFormat("0E0").format(
-				Math.pow(10, SerialSimulatedAnnealing.max_exp-SerialSimulatedAnnealing.exp_orders_of_mag)).toLowerCase();
-		
-		String scaleStr = "perturb_exp_scale_1e-2_to_"+minScaleStr;
-		dirName += "perturb(EXP_SCA)_nonNeg(RY_OFTEN)_Averaging(16,1)_water(1e-2)_expOrd(10)_U3PERTURBHACK(NA)_time(15m,15s,15s)";
+//		SerialSimulatedAnnealing.exp_orders_of_mag = 10;
+//		String minScaleStr = new DecimalFormat("0E0").format(
+//				Math.pow(10, SerialSimulatedAnnealing.max_exp-SerialSimulatedAnnealing.exp_orders_of_mag)).toLowerCase();
+//
+//		String scaleStr = "perturb_exp_scale_1e-2_to_"+minScaleStr;
+//		dirName += "perturb(EXP_SCA)_nonNeg(RY_OFTEN)_Averaging(16,1)_water(1e-2)_expOrd(10)_U3PERTURBHACK(NA)_time(15m,15s,15s)";
 		
 		System.out.println(dirName);
 		CoulombRupSetConfig rsConfig = new RuptureSets.CoulombRupSetConfig(fm, scale);
@@ -163,7 +134,7 @@ class FullPipelineCrustal {
 //				List<IncrementalMagFreqDist> solutionMfds = ((NZSHM22_CrustalInversionTargetMFDs) inversionConfiguration.getInversionTargetMfds()).getMFDConstraintComponents();
 			
 				// set up slip rate config
-				inversionConfiguration.setSlipRateWeightingType(SlipRateConstraintWeightingType.BOTH);
+				inversionConfiguration.setSlipRateWeightingType(AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.BOTH);
 				double slipRateConstraintWt_normalized = 1000;
 				double slipRateConstraintWt_unnormalized = 1000;
 				
@@ -173,9 +144,9 @@ class FullPipelineCrustal {
 				/*
 				 * Build inversion inputs
 				 */
-				List<AveSlipConstraint> aveSlipConstraints = null;
+
 				NZSHM22_CrustalInversionInputGenerator inputGen = new NZSHM22_CrustalInversionInputGenerator(
-						(NZSHM22_InversionFaultSystemRuptSet) rupSet, inversionConfiguration, null, aveSlipConstraints, null, null);				
+						(NZSHM22_InversionFaultSystemRuptSet) rupSet, inversionConfiguration, null, null, null, null);
 				
 //				InversionTargetMFDs targetMFDs = rupSet.requireModule(NZSHM22_CrustalInversionTargetMFDs.class);
 				

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/scripts/scriptCrustalInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/scripts/scriptCrustalInversionRunner.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_FaultModels;
+import nz.cri.gns.NZSHM22.opensha.inversion.AbstractInversionConfiguration;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
@@ -25,7 +26,6 @@ import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import scratch.UCERF3.SlipAlongRuptureModelRupSet;
-import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
 import scratch.UCERF3.utils.U3FaultSystemIO;
 
 /**
@@ -33,7 +33,7 @@ import scratch.UCERF3.utils.U3FaultSystemIO;
  */
 public class scriptCrustalInversionRunner {
 
-    private static SlipRateConstraintWeightingType weightingType = SlipRateConstraintWeightingType.UNCERTAINTY_ADJUSTED;
+    private static AbstractInversionConfiguration.NZSlipRateConstraintWeightingType weightingType = AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.NORMALIZED_BY_UNCERTAINTY;
 
 	public static CommandLine parseCommandLine(String[] args) throws ParseException {
 

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/util/MFDPlotBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/util/MFDPlotBuilder.java
@@ -68,11 +68,11 @@ public class MFDPlotBuilder {
 //    			"InversionSolution-RmlsZToz-rnd0-t1380_RmlsZTo1MTYuMGQ3WlVz.zip"; //LONG CFM 3
 //    	String solution = "/home/chrisbc/DEV/GNS/opensha-new/DATA/2021-06-01-01/UnVwdHVyZUdlbmVyYXRpb25UYXNrOjE4MFJFWXF4" + 
 //    			"/" + "InversionSolution-RmlsZTo5-rnd0-t1380_RmlsZTo1MjIuMDN2ZktR.zip"; //LONG CFM 9
-    	String solution = "src/python/automation/tmp/downloads/RmlsZToxMTA3LjBYNzNpMw==/NZSHM22_InversionSolution-UnVwdHVyZUdlbmVyYXRpb25UYXNrOjQ4Nk16REF5_RmlsZToxMTA3LjBYNzNpMw==.zip";
+    	String solution = "C:\\Users\\volkertj\\Downloads\\NZSHM22_InversionSolution-QXV0b21hdGlvblRhc2s6NTA3MHRBZ3dG.zip";
     	  				
         new MFDPlotBuilder()
                 .setOutputDir("/tmp/mfd")
-                .setFaultModel("CFM_0_3_SANSTVZ") // optional, set if you only want to plot named faults
+                .setFaultModel("CFM_0_9_SANSTVZ_D90") // optional, set if you only want to plot named faults
                 .setCrustalSolution(solution)
                 .plot();
         

--- a/src/main/java/nz/cri/gns/NZSHM22/util/NZSHM22_ReportPageGen.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/util/NZSHM22_ReportPageGen.java
@@ -7,7 +7,9 @@ import org.opensha.sha.earthquake.faultSysSolution.reports.plots.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class NZSHM22_ReportPageGen {
 
@@ -46,6 +48,16 @@ public class NZSHM22_ReportPageGen {
         return this;
     }
 
+    static Map<String, AbstractRupSetPlot> possiblePlots;
+
+    static{
+        possiblePlots = new HashMap<>();
+        List<AbstractRupSetPlot> choices = ReportPageGen.getDefaultSolutionPlots(ReportPageGen.PlotLevel.FULL);
+        for(AbstractRupSetPlot plot : choices){
+            possiblePlots.put(choices.getClass().getSimpleName(), plot);
+        }
+    }
+
     /**
      * Adds a specific plot to the report.
      * @param plotName
@@ -55,42 +67,11 @@ public class NZSHM22_ReportPageGen {
         if (plots == null) {
             plots = new ArrayList<>();
         }
-        switch (plotName) {
-            case "SolMFDPlot":
-                plots.add(new SolMFDPlot());
-                break;
-            case "InversionProgressPlot":
-                plots.add(new InversionProgressPlot());
-                break;
-            case "RateVsRateScatter":
-                plots.add(new RateVsRateScatter());
-                break;
-            case "ParticipationRatePlot":
-                plots.add(new ParticipationRatePlot());
-                break;
-            case "PlausibilityConfigurationReport":
-                plots.add(new PlausibilityConfigurationReport());
-                break;
-            case "RupHistogramPlots":
-                plots.add(new RupHistogramPlots());
-                break;
-            case "FaultSectionConnectionsPlot":
-                plots.add(new FaultSectionConnectionsPlot());
-                break;
-            case "SlipRatePlots":
-                plots.add(new SlipRatePlots());
-                break;
-            case "JumpCountsOverDistancePlot":
-                plots.add(new JumpCountsOverDistancePlot());
-                break;
-            case "SegmentationPlot":
-                plots.add(new SegmentationPlot());
-                break;
-            case "SectBySectDetailPlots":
-                plots.add(new SectBySectDetailPlots());
-                break;
-            default:
-                throw new IllegalArgumentException("not a valid plot: " + plotName);
+        AbstractRupSetPlot plot = possiblePlots.get(plotName);
+        if (plot != null) {
+            plots.add(plot);
+        } else {
+            throw new IllegalArgumentException("not a valid plot: " + plotName);
         }
         return this;
     }

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_SubductionInversionTargetMFDsTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_SubductionInversionTargetMFDsTest.java
@@ -4,6 +4,7 @@ import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_LogicTreeBranch;
 import org.dom4j.DocumentException;
 import org.junit.Test;
 import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
 import scratch.UCERF3.utils.MFD_InversionConstraint;
 
 import java.awt.geom.Point2D;
@@ -37,14 +38,14 @@ public class NZSHM22_SubductionInversionTargetMFDsTest {
         NZSHM22_InversionFaultSystemRuptSet ruptSet = loadRupSet();
         NZSHM22_SubductionInversionTargetMFDs mfds = new NZSHM22_SubductionInversionTargetMFDs(ruptSet);
 
-        List<MFD_InversionConstraint> actual = (List<MFD_InversionConstraint>) mfds.getMFD_Constraints();
+        List<IncrementalMagFreqDist> actual = mfds.getMFD_Constraints();
 
         assertEquals(1, actual.size());
-        MFD_InversionConstraint actualConstraint = actual.get(0);
+        IncrementalMagFreqDist actualConstraint = actual.get(0);
 
-        assertEquals("targetOnFaultSupraSeisMFD", actualConstraint.getMagFreqDist().getName());
+        assertEquals("targetOnFaultSupraSeisMFD", actualConstraint.getName());
         assertNull(actualConstraint.getRegion());
         assertEquals(List.of(5.05, 1.0E-20, 5.1499999999999995, 1.0E-20, 5.25, 1.0E-20, 5.35, 1.0E-20, 5.45, 1.0E-20, 5.55, 1.0E-20, 5.65, 1.0E-20, 5.75, 1.0E-20, 5.85, 1.0E-20, 5.95, 1.0E-20, 6.05, 1.0E-20, 6.15, 1.0E-20, 6.25, 1.0E-20, 6.35, 1.0E-20, 6.45, 1.0E-20, 6.55, 1.0E-20, 6.65, 1.0E-20, 6.75, 1.0E-20, 6.85, 1.0E-20, 6.95, 1.0E-20, 7.05, 9.884813984399915E-4, 7.15, 7.673058353801398E-4, 7.25, 5.956189422862039E-4, 7.35, 4.6234748655909656E-4, 7.45, 3.58895903322022E-4, 7.55, 2.785919101235696E-4, 7.65, 2.1625616694949997E-4, 7.75, 1.6786822604772256E-4, 7.85, 1.3030722644311824E-4, 7.95, 1.0115060880235229E-4, 8.05, 7.85178684280625E-5, 8.15, 6.094926897111459E-5, 8.25, 4.731169429945435E-5, 8.35, 0.0, 8.45, 0.0, 8.55, 0.0, 8.65, 0.0, 8.75, 0.0, 8.85, 0.0, 8.95, 0.0, 9.05, 0.0, 9.15, 0.0, 9.25, 0.0, 9.35, 0.0, 9.45, 0.0, 9.55, 0.0, 9.65, 0.0),
-                getPoints(actualConstraint.getMagFreqDist()));
+                getPoints(actualConstraint));
     }
 }


### PR DESCRIPTION
closes #69 

Builds and runs against latest upstream `8ca4d4c0b2abf5a25889af41f4de427ef8173271`

Just makes everything compile, does not make use of new features (Kevin had said, "You especially might find my InversionConfiguration utility class useful for setting up annealing instances for various thread & sa param options.")

We should choose a better generation function than `GenerationFunctionType.UNIFORM_0p001`