### PR TITLE
better CrustalMFDRunner

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/CrustalMFDRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/CrustalMFDRunner.java
@@ -1,13 +1,10 @@
 package nz.cri.gns.NZSHM22.opensha.inversion;
 
-import com.google.common.base.Preconditions;
-import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_DeformationModel;
-import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_LogicTreeBranch;
-import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_ScalingRelationshipNode;
-import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_SpatialSeisPDF;
+import nz.cri.gns.NZSHM22.opensha.calc.SimplifiedScalingRelationship;
 import nz.cri.gns.NZSHM22.opensha.reports.NZSHM22_MFDPlot;
+import nz.cri.gns.NZSHM22.opensha.util.NZSHM22_PythonGateway;
 import org.dom4j.DocumentException;
-import org.opensha.sha.earthquake.faultSysSolution.RupSetScalingRelationship;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.reports.ReportMetadata;
 import org.opensha.sha.earthquake.faultSysSolution.reports.ReportPageGen;
 import org.opensha.sha.earthquake.faultSysSolution.reports.RupSetMetadata;
@@ -18,88 +15,11 @@ import java.util.List;
 
 public class CrustalMFDRunner {
 
-    private double totalRateM5_Sans = 3.6;
-    private double totalRateM5_TVZ = 0.4;
-    private double bValue_Sans = 1.05;
-    private double bValue_TVZ = 1.25;
-    double minMagSans = 7.0;
-    double minMagTvz = 7.0;
-
-    protected NZSHM22_ScalingRelationshipNode scalingRelationship;
-    protected NZSHM22_DeformationModel deformationModel = null;
-    private NZSHM22_SpatialSeisPDF spatialSeisPDF = null;
-    protected NZSHM22_InversionFaultSystemRuptSet rupSet = null;
-
     String outputPath = "TEST/mfd";
     String name = "MFD Plot";
-    private double mfdUncertaintyPower;
-
-    public CrustalMFDRunner setScalingRelationship(String scalingRelationship, boolean recalcMags) {
-        return setScalingRelationship(NZSHM22_ScalingRelationshipNode.createRelationShip(scalingRelationship), recalcMags);
-    }
-
-    public CrustalMFDRunner setScalingRelationship(RupSetScalingRelationship scalingRelationship, boolean recalcMags) {
-        this.scalingRelationship = new NZSHM22_ScalingRelationshipNode();
-        this.scalingRelationship.setScalingRelationship(scalingRelationship);
-        this.scalingRelationship.setRecalc(recalcMags);
-        return this;
-    }
-
-    public CrustalMFDRunner setDeformationModel(String modelName) {
-        Preconditions.checkArgument(rupSet == null, "rupture set must be set after deformation model.");
-        this.deformationModel = NZSHM22_DeformationModel.valueOf(modelName);
-        return this;
-    }
-
-    public CrustalMFDRunner setSpatialSeisPDF(NZSHM22_SpatialSeisPDF spatialSeisPDF) {
-        this.spatialSeisPDF = spatialSeisPDF;
-        return this;
-    }
-
-    public CrustalMFDRunner setMinMags(double minMagSans, double minMagTvz){
-        this.minMagSans = minMagSans;
-        this.minMagTvz = minMagTvz;
-        return this;
-    }
-
-    public CrustalMFDRunner setMfdUncertaintyPowers(double mfdUncertaintyPower){
-        this.mfdUncertaintyPower = mfdUncertaintyPower;
-        return this;
-    }
 
     public CrustalMFDRunner setName(String name) {
         this.name = name;
-        return this;
-    }
-
-    public CrustalMFDRunner setGutenbergRichterMFD(double totalRateM5_Sans, double totalRateM5_TVZ,
-                                                   double bValue_Sans, double bValue_TVZ) {
-        this.totalRateM5_Sans = totalRateM5_Sans;
-        this.totalRateM5_TVZ = totalRateM5_TVZ;
-        this.bValue_Sans = bValue_Sans;
-        this.bValue_TVZ = bValue_TVZ;
-        return this;
-    }
-
-    protected void setupLTB(NZSHM22_LogicTreeBranch branch) {
-        if (scalingRelationship != null) {
-            branch.clearValue(NZSHM22_ScalingRelationshipNode.class);
-            branch.setValue(scalingRelationship);
-        }
-        if (deformationModel != null) {
-            branch.setValue(deformationModel);
-        }
-        if (spatialSeisPDF != null) {
-            branch.clearValue(NZSHM22_SpatialSeisPDF.class);
-            branch.setValue(spatialSeisPDF);
-        }
-    }
-
-    public CrustalMFDRunner setRuptureSetFile(File ruptureSetFile) throws DocumentException, IOException {
-        NZSHM22_LogicTreeBranch branch = NZSHM22_LogicTreeBranch.crustalInversion();
-        setupLTB(branch);
-        this.rupSet = NZSHM22_InversionFaultSystemRuptSet.loadRuptureSet(ruptureSetFile, branch);
-
         return this;
     }
 
@@ -108,31 +28,89 @@ public class CrustalMFDRunner {
         return this;
     }
 
-    public void run() throws IOException {
-        NZSHM22_CrustalInversionTargetMFDs targetMfds = new NZSHM22_CrustalInversionTargetMFDs(rupSet, totalRateM5_Sans, totalRateM5_TVZ, bValue_Sans, bValue_TVZ, minMagSans, minMagTvz, mfdUncertaintyPower);
-        rupSet.addModule(targetMfds);
+    /**
+     * Creates MFD plots on a runner before an inversion is run.
+     * Good for a quick turnaround when playing with MFD settings, does not include solution MFD.
+     * @param runner
+     * @throws IOException
+     * @throws DocumentException
+     */
+    public void runBeforeInversion(NZSHM22_CrustalInversionRunner runner) throws IOException, DocumentException {
 
-        //rupSet.write(new File(outputPath, "rupSet.zip"));
+        runner.configure();
 
         NZSHM22_MFDPlot plot = new NZSHM22_MFDPlot();
-        RupSetMetadata rupMeta = new RupSetMetadata(name, rupSet);
+        RupSetMetadata rupMeta = new RupSetMetadata(name, runner.rupSet);
         ReportMetadata meta = new ReportMetadata(rupMeta);
 
         ReportPageGen rupReport = new ReportPageGen(meta, new File(outputPath), List.of(plot));
         rupReport.generatePage();
     }
 
-    public static void main(String[] args) throws DocumentException, IOException {
+    /**
+     * Runs the specified runner and generates MFD plots on the solution.
+     * RegionalTargetMFDs don't yet write all MFDs to file, so some curves can only be plotted like this.
+     * @param runner
+     * @throws IOException
+     * @throws DocumentException
+     */
+    public void runOnSolution(NZSHM22_CrustalInversionRunner runner) throws IOException, DocumentException {
 
-        CrustalMFDRunner runner = new CrustalMFDRunner()
+        FaultSystemSolution solution = runner.runInversion();
+        solution.write(new File(outputPath, "/solution.zip"));
+
+        NZSHM22_MFDPlot plot = new NZSHM22_MFDPlot();
+        RupSetMetadata rupMeta = new RupSetMetadata(name, solution.getRupSet(), solution);
+        ReportMetadata meta = new ReportMetadata(rupMeta);
+
+        ReportPageGen rupReport = new ReportPageGen(meta, new File(outputPath), List.of(plot));
+        rupReport.generatePage();
+
+    }
+
+    /**
+     * Plots MFDs for the specified solution file.
+     * @param solutionFile
+     * @throws IOException
+     */
+    public void runOnSolution(String solutionFile) throws IOException {
+        NZSHM22_InversionFaultSystemSolution solution = NZSHM22_InversionFaultSystemSolution.fromFile(new File(solutionFile));
+        NZSHM22_MFDPlot plot = new NZSHM22_MFDPlot();
+        RupSetMetadata rupMeta = new RupSetMetadata(name, solution.getRupSet(), solution);
+        ReportMetadata meta = new ReportMetadata(rupMeta);
+
+        ReportPageGen rupReport = new ReportPageGen(meta, new File(outputPath), List.of(plot));
+        rupReport.generatePage();
+
+    }
+
+    public static void main(String[] args) throws DocumentException, IOException {
+        SimplifiedScalingRelationship scaling = (SimplifiedScalingRelationship) NZSHM22_PythonGateway.getScalingRelationship("SimplifiedScalingRelationship");
+        scaling.setupCrustal(4, 4.1);
+
+
+        NZSHM22_CrustalInversionRunner runner = new NZSHM22_CrustalInversionRunner();
+
+        runner
+                .setMinMags(7.0, 6.5)
+                .setGutenbergRichterMFD(4.0, 0.81, 0.91, 1.05, 7.85)
+                .setPaleoRateConstraints(1000.0, 100.0, "GEODETIC_SLIP_4FEB", "NZSHM22_C_42") //RUNZI updated [x]
+
+                .setInversionSeconds(10)
+                .setScalingRelationship(scaling, true)
+                //   .setDeformationModel("GEOD_NO_PRIOR_UNISTD_2010_RmlsZTo4NTkuMDM2Z2Rw")
+                .setRuptureSetFile("C:\\Users\\volkertj\\Downloads\\NZSHM22_RuptureSet-UnVwdHVyZUdlbmVyYXRpb25UYXNrOjc5OTBvWWZMVw==.zip")
+                .setGutenbergRichterMFDWeights(100.0, 1000.0)
+                .setSlipRateConstraint("BOTH", 1000, 1000)
+        ;
+
+        CrustalMFDRunner mfdRunner = new CrustalMFDRunner();
+        mfdRunner
                 .setName("NZSHM22 MFD Plots")
                 .setOutputPath("TEST/mfd")
-                .setScalingRelationship("SMPL_NZ_INT_UP", false)
-                .setRuptureSetFile(new File("C:\\Users\\volkertj\\Downloads\\RupSet_Cl_FM(CFM_0_9_SANSTVZ_D90)_noInP(T)_slRtP(0.05)_slInL(F)_cfFr(0.75)_cfRN(2)_cfRTh(0.5)_cfRP(0.01)_fvJm(T)_jmPTh(0.001)_cmRkTh(360)_mxJmD(15)_plCn(T)_adMnD(6)_adScFr(0)_bi(F)_stGrSp(2)_coFr(0.5)(4).zip"))
-                .setGutenbergRichterMFD(4.3, 0.8, 0.89, 0.89)
-                .setMinMags(6.95, 6.95);
+                .runOnSolution(runner);
 
-        runner.run();
+
     }
 
 


### PR DESCRIPTION
Makes it easier to quickly create MFD plots from the command line. These changes make sure we use a runner, meaning we always use the latest MFD settings and don't need to duplicate them here - especially important now that we've got regional MFDs