### PR TITLE
catch up with new method in opensha FaultGridAssociations interface

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/griddedSeismicity/NZSHM22_FaultPolyMgr.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/griddedSeismicity/NZSHM22_FaultPolyMgr.java
@@ -75,6 +75,11 @@ public class NZSHM22_FaultPolyMgr implements Iterable<Area>, PolygonFaultGridAss
     }
 
     @Override
+    public Map<Integer, Double> getScaledSectFracsOnNode(int nodeIdx) {
+        return sectInNodePartic.column(nodeIdx);
+    }
+
+    @Override
     public Map<Integer, Double> getNodeFractions(int sectIdx) {
         return nodeInSectPartic.row(sectIdx);
     }


### PR DESCRIPTION
This catches up with a minor change in opensha that added a new method in the FaultGridAssociations interface. The method lets you quickly find sections associated with each node with the correct weights, and all data is already in the sectInNodePartic Table in your implementation.