### PR TITLE
[308] merge opensha upstream

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/util/SimpleGeoJsonBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/util/SimpleGeoJsonBuilder.java
@@ -109,12 +109,7 @@ public class SimpleGeoJsonBuilder {
 
     public String toJSON() {
         FeatureCollection featureCollection = new FeatureCollection(features);
-        try {
-            return featureCollection.toJSON();
-        } catch (IOException x) {
-            x.printStackTrace();
-        }
-        return null;
+        return featureCollection.toJSON();
     }
 
     public void toJSON(File file) {


### PR DESCRIPTION
implements #308 

`opensha` has removed a `throws` clause from a method we call, so we have to adjust our code.

Once this is merged, the project will not build until our `opensha` fork is updated.