### PR TITLE
[315] Calculate joint rupture length

### DIFF
--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/ruptures/MixedRuptureSetBuilderTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/ruptures/MixedRuptureSetBuilderTest.java
@@ -1,0 +1,198 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MixedRuptureSetBuilderTest {
+
+
+    @Test
+    public void testSingleCrustalSection() {
+        MixedRuptureSetBuilder builder = mockBuilder(
+                new MockRupture(
+                        mockCrustalCluster(30))
+        );
+        double[] actual = builder.buildLengths();
+
+        assertArrayEquals(new double[]{(30) * 1000}, actual, 0.0000001);
+    }
+
+    @Test
+    public void testSingleCrustalCluster() {
+        MixedRuptureSetBuilder builder = mockBuilder(
+                new MockRupture(
+                        mockCrustalCluster(10, 20, 30))
+        );
+        double[] actual = builder.buildLengths();
+
+        assertArrayEquals(new double[]{(10 + 20 + 30) * 1000}, actual, 0.0000001);
+    }
+
+    @Test
+    public void testCrustalClusters() {
+        MixedRuptureSetBuilder builder = mockBuilder(
+                new MockRupture(
+                        mockCrustalCluster(10, 20, 30),
+                        mockCrustalCluster(40, 50, 60))
+        );
+        double[] actual = builder.buildLengths();
+
+        assertArrayEquals(new double[]{(10 + 20 + 30 + 40 + 50 + 60) * 1000}, actual, 0.0000001);
+    }
+
+    @Test
+    public void testSingleDownDipSection() {
+        MixedRuptureSetBuilder builder = mockBuilder(
+                new MockRupture(
+                        mockDownDipCluster(
+                                mockDownDipRow(0, 10)
+                        ))
+        );
+        double[] actual = builder.buildLengths();
+
+        assertArrayEquals(new double[]{(10) * 1000}, actual, 0.0000001);
+    }
+
+    @Test
+    public void testSingleDownDipCluster() {
+        MixedRuptureSetBuilder builder = mockBuilder(
+                new MockRupture(
+                        mockDownDipCluster(
+                                mockDownDipRow(1, 30, 40),
+                                mockDownDipRow(0, 10, 20), // this is the top row
+                                mockDownDipRow(2, 50, 60)
+                        ))
+        );
+        double[] actual = builder.buildLengths();
+
+        assertArrayEquals(new double[]{(10 + 20) * 1000}, actual, 0.0000001);
+    }
+
+    @Test
+    public void testUnevenDownDipCluster() {
+        MixedRuptureSetBuilder builder = mockBuilder(
+                new MockRupture(
+                        mockDownDipCluster(
+                                mockDownDipRow(1, 30, 40, 50),
+                                mockDownDipRow(0, 10, 20), // this is the top row
+                                mockDownDipRow(2, 50, 60)
+                        ))
+        );
+        double[] actual = builder.buildLengths();
+
+        assertArrayEquals(new double[]{(10 + 20) * 1000}, actual, 0.0000001);
+    }
+
+    @Test
+    public void testJointRupture() {
+        MixedRuptureSetBuilder builder = mockBuilder(
+                new MockRupture(
+                        mockCrustalCluster(70, 80, 90),
+                        mockDownDipCluster(
+                                mockDownDipRow(1, 30, 40),
+                                mockDownDipRow(0, 10, 20), // this is the top row
+                                mockDownDipRow(2, 50, 60)
+                        ))
+        );
+        double[] actual = builder.buildLengths();
+
+        assertArrayEquals(new double[]{(70 + 80 + 90 + 10 + 20) * 1000}, actual, 0.0000001);
+    }
+
+    @Test
+    public void testMultipleRupture() {
+        MixedRuptureSetBuilder builder = mockBuilder(
+                new MockRupture(
+                        mockCrustalCluster(70, 80, 90),
+                        mockDownDipCluster(
+                                mockDownDipRow(1, 30, 40),
+                                mockDownDipRow(0, 10, 20), // this is the top row
+                                mockDownDipRow(2, 50, 60)
+                        )),
+                new MockRupture(
+                        mockCrustalCluster(70, 80, 90)
+                ),
+                new MockRupture(
+                        mockDownDipCluster(
+                                mockDownDipRow(1, 30, 40),
+                                mockDownDipRow(0, 10, 20), // this is the top row
+                                mockDownDipRow(2, 50, 60)
+                        ))
+        );
+        double[] actual = builder.buildLengths();
+
+        assertArrayEquals(new double[]{
+                (70 + 80 + 90 + 10 + 20) * 1000,
+                (70 + 80 + 90) * 1000,
+                (10 + 20) * 1000
+        }, actual, 0.0000001);
+    }
+
+    static MixedRuptureSetBuilder mockBuilder(ClusterRupture... ruptures) {
+        MixedRuptureSetBuilder builder = new MixedRuptureSetBuilder();
+        builder.ruptures = ImmutableList.copyOf(ruptures);
+        return builder;
+    }
+
+    static class MockRupture extends ClusterRupture {
+
+        static ImmutableList<Jump> makeJumps(FaultSubsectionCluster[] clusters) {
+            List<Jump> jumps = new ArrayList<>();
+            for (int i = 0; i < clusters.length - 1; i++) {
+                jumps.add(mock(Jump.class));
+            }
+            return ImmutableList.copyOf(jumps);
+        }
+
+        public MockRupture(FaultSubsectionCluster... clusters) {
+            super(clusters, makeJumps(clusters), ImmutableMap.of(), clusters[0].unique, clusters[0].unique, true);
+        }
+    }
+
+    static int sectionId = 0;
+
+    public static FaultSubsectionCluster mockCrustalCluster(double... lengths) {
+        List<FaultSection> subSects = new ArrayList<>();
+        for (double length : lengths) {
+            FaultSection s = mock(FaultSection.class);
+            when(s.getSectionId()).thenReturn(sectionId++);
+            when(s.getTraceLength()).thenReturn(length);
+            subSects.add(s);
+        }
+        return new FaultSubsectionCluster(subSects);
+    }
+
+    public static List<FaultSection> mockDownDipRow(int rowIndex, double... lengths) {
+        List<FaultSection> subSects = new ArrayList<>();
+        for (double length : lengths) {
+            DownDipFaultSection s = mock(DownDipFaultSection.class);
+            when(s.getSectionId()).thenReturn(sectionId++);
+            when(s.getRowIndex()).thenReturn(rowIndex);
+            when(s.getTraceLength()).thenReturn(length);
+            subSects.add(s);
+        }
+        return subSects;
+    }
+
+    public static FaultSubsectionCluster mockDownDipCluster(List<FaultSection>... rows) {
+        List<FaultSection> subSects = new ArrayList<>();
+        for (List<FaultSection> row : rows) {
+            subSects.addAll(row);
+        }
+        return new FaultSubsectionCluster(subSects);
+    }
+
+
+}


### PR DESCRIPTION
Implements #315 

`Opensha` calculates rupture lengths by summing up trace length over all sections. For subduction ruptures, not all sections contribute to the length. This PR enables `MixedRuptureSetBuilder` to calculate rupture length correctly based on the algorithm used in `NZSHM22`: for a subduction cluster, find the most up-dip row and sum the trance length of all sections in that row.

Note that this might change the lengths of pure crustal ruptures based on floating point artifacts.