### PR TITLE
[323] Joint rupture builder experiment

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/enumTreeBranches/NZSHM22_FaultModels.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/enumTreeBranches/NZSHM22_FaultModels.java
@@ -96,7 +96,7 @@ public enum NZSHM22_FaultModels implements LogicTreeNode {
 			"hk_tile_parameters_creeping_trench_slip_deficit_v2a_30.csv", 10000),
 	@Deprecated
 	SBD_0_3_HKR_LR_30("Hikurangi, Kermadec to Louisville ridge, 30km - with slip deficit smoothed near East Cape and locked near trench.",
-					  "hk_tile_parameters_locked_trench_slip_deficit_v2_30.csv", 10000),
+					  "hk_tile_parameters_locked_trench_slip_deficit_v2_30.csv", 20000),
     @Deprecated
 	SBD_0_4_HKR_LR_30("Hikurangi, Kermadec to Louisville ridge, 30km - higher overall slip rates, aka Kermits revenge",
 			"hk_tile_parameters_highkermsliprate_v2.csv", 10000);
@@ -203,8 +203,12 @@ public enum NZSHM22_FaultModels implements LogicTreeNode {
 		return getName();
 	}
 
-	public String getFileName(){
+	public String getFileName() {
 		return fileName;
+	}
+
+	public int getParentSectionId() {
+		return id;
 	}
 
 	@Override

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/DownDipFaultSection.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/DownDipFaultSection.java
@@ -22,6 +22,10 @@ public class DownDipFaultSection extends FaultSectionPrefData {
 	private int colIndex = Integer.MAX_VALUE;
 	private DownDipSubSectBuilder builder;
 
+    private volatile double traceLength = -1;
+    private volatile double creepArea = -1;
+    private volatile double noCreepArea = -1;
+
     public DownDipFaultSection setBuilder(DownDipSubSectBuilder builder) {
         this.builder = builder;
         return this;
@@ -76,6 +80,28 @@ public class DownDipFaultSection extends FaultSectionPrefData {
 	public int getColIndex() {
 		return this.colIndex;
 	}
+
+    @Override
+    public double getTraceLength() {
+        if (traceLength < 0) {
+            traceLength = super.getTraceLength();
+        }
+        return traceLength;
+    }
+
+    @Override
+    public double getArea(boolean creepReduced) {
+        if (creepReduced) {
+            if (creepArea < 0) {
+                creepArea = super.getArea(creepReduced);
+            }
+            return creepArea;
+        }
+        if (noCreepArea < 0) {
+            noCreepArea = super.getArea(creepReduced);
+        }
+        return noCreepArea;
+    }
 
 	public String toString() {
 		String str = "type = DownDipFaultSection\n";

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_AbstractRuptureSetBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_AbstractRuptureSetBuilder.java
@@ -29,7 +29,7 @@ public abstract class NZSHM22_AbstractRuptureSetBuilder {
 	PlausibilityConfiguration plausibilityConfig;
 	
     protected FaultSectionList subSections;
-    List<ClusterRupture> ruptures;
+    protected List<ClusterRupture> ruptures;
     ClusterRuptureBuilder builder;
 
     File fsdFile = null;
@@ -37,11 +37,11 @@ public abstract class NZSHM22_AbstractRuptureSetBuilder {
     String downDipFaultName = null;
     NZSHM22_FaultModels faultModel = null;
 
-    int minSubSectsPerParent = 2; // 2 are required for UCERf3 azimuth calcs
+    protected int minSubSectsPerParent = 2; // 2 are required for UCERf3 azimuth calcs
     int minSubSections = 2; // New NZSHM22
 
     double maxSubSectionLength = 0.5; // maximum sub section length (in units of DDW)
-    int numThreads = Runtime.getRuntime().availableProcessors(); // use all available processors
+    protected int numThreads = Runtime.getRuntime().availableProcessors(); // use all available processors
 
 	protected RupSetScalingRelationship scalingRelationship = ScalingRelationships.SHAW_2009_MOD;
 	protected SlipAlongRuptureModels slipAlongRuptureModel = SlipAlongRuptureModels.UNIFORM;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/downDip/DownDipFaultSubSectionCluster.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/downDip/DownDipFaultSubSectionCluster.java
@@ -1,0 +1,86 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.downDip;
+
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A FaultSubsectionCluster for subduction faults. Has some convenience methods.
+ */
+public class DownDipFaultSubSectionCluster extends FaultSubsectionCluster {
+
+    public final List<DownDipFaultSection> ddSections;
+
+    public DownDipFaultSubSectionCluster(List<? extends FaultSection> subSects) {
+        this(subSects, null);
+    }
+
+    public DownDipFaultSubSectionCluster(List<? extends FaultSection> subSects, Collection<FaultSection> endSects) {
+        super(subSects, endSects);
+        ddSections = (List<DownDipFaultSection>) subSects;
+    }
+
+    /**
+     * Reverses the cluster per row, preserving the row order.
+     *
+     * @return the reversed cluster
+     */
+    @Override
+    public DownDipFaultSubSectionCluster reversed() {
+        List<DownDipFaultSection> newSections = new ArrayList<>();
+        List<DownDipFaultSection> currentRow = new ArrayList<>();
+        int currentRowId = ddSections.get(0).getRowIndex();
+
+        for (DownDipFaultSection section : ddSections) {
+            if (section.getSectionId() != currentRowId) {
+                Collections.reverse(currentRow);
+                newSections.addAll(currentRow);
+                currentRow = new ArrayList<>();
+                currentRowId = section.getRowIndex();
+            }
+            currentRow.add(section);
+        }
+        if (!currentRow.isEmpty()) {
+            Collections.reverse(currentRow);
+            newSections.addAll(currentRow);
+        }
+        return new DownDipFaultSubSectionCluster(newSections, endSects);
+    }
+
+    @Override
+    public DownDipFaultSubSectionCluster reversed(FaultSection section) {
+        throw new RuntimeException("Not implemented");
+    }
+
+
+    public DownDipFaultSection first() {
+        return ddSections.get(0);
+    }
+
+    private DownDipFaultSection lastSection = null;
+
+    /**
+     * Get the last section in the topmost row.
+     *
+     * @return the last section in the topmost row
+     */
+    public FaultSection last() {
+        if (lastSection == null) {
+            List<DownDipFaultSection> trace = getTraceSections();
+            lastSection = trace.get(trace.size() - 1);
+        }
+        return lastSection;
+    }
+
+    /**
+     * Returns all sections form the topmost row.
+     *
+     * @return
+     */
+    public List<DownDipFaultSection> getTraceSections() {
+        return ddSections.stream().filter(s -> s.getRowIndex() == first().getRowIndex()).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/downDip/DownDipPermutationStrategy.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/downDip/DownDipPermutationStrategy.java
@@ -128,7 +128,7 @@ public class DownDipPermutationStrategy implements RuptureGrowingStrategy {
             }
         }
         Preconditions.checkState(subsetSects.get(0).equals(downDipBuilder.getSubSect(startRow, startCol)));
-        FaultSubsectionCluster permutation = new FaultSubsectionCluster(subsetSects, exitPoints);
+        FaultSubsectionCluster permutation = new DownDipFaultSubSectionCluster(subsetSects, exitPoints);
         // add possible jumps out of this permutation
         for (FaultSection sect : subsetSects)
             for (Jump jump : fullCluster.getConnections(sect))

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/downDip/FaultTypeSeparationConnectionStrategy.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/downDip/FaultTypeSeparationConnectionStrategy.java
@@ -10,7 +10,7 @@ import org.opensha.sha.faultSurface.FaultSection;
 import java.util.List;
 
 /**
- * Like DistCutoffClosestSectClusterConnectionStrategy but ensures that we don not create jumps from or to
+ * Like DistCutoffClosestSectClusterConnectionStrategy but ensures that we do not create jumps from or to
  * downdip faults.
  */
 public class FaultTypeSeparationConnectionStrategy extends DistCutoffClosestSectClusterConnectionStrategy {

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/DownDipRuptureGrowthPlausibilityFilter.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/DownDipRuptureGrowthPlausibilityFilter.java
@@ -1,0 +1,42 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
+
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityResult;
+
+
+/**
+ * Used in MixedRuptureSetBuilder. Ensures that jumps can only go to and from the top row of a subduction cluster.
+ * <p>
+ * Based on a wrong assumption. Only kept for the duration of the experimental joint rupture phase.
+ */
+public class DownDipRuptureGrowthPlausibilityFilter implements PlausibilityFilter {
+    @Override
+    public PlausibilityResult apply(ClusterRupture rupture, boolean verbose) {
+        for (Jump jump : rupture.getJumpsIterable()) {
+
+//            if(jump.fromSection instanceof DownDipFaultSection || jump.toSection instanceof DownDipFaultSection) {
+//                System.out.println("what");
+//            }
+            if (jump.fromSection instanceof DownDipFaultSection && ((DownDipFaultSection) jump.fromSection).getRowIndex() > ((DownDipFaultSection) jump.fromCluster.startSect).getRowIndex()) {
+                return PlausibilityResult.FAIL_HARD_STOP;
+            }
+            if (jump.toSection instanceof DownDipFaultSection && ((DownDipFaultSection) jump.toSection).getRowIndex() > ((DownDipFaultSection) jump.toCluster.startSect).getRowIndex()) {
+                return PlausibilityResult.FAIL_HARD_STOP;
+            }
+        }
+        return PlausibilityResult.PASS;
+    }
+
+    @Override
+    public String getShortName() {
+        return "DownDipRuptureGrowthPlausibilityFilter";
+    }
+
+    @Override
+    public String getName() {
+        return "DownDipRuptureGrowthPlausibilityFilter";
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/DownDipRuptureSizePlausibilityFilter.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/DownDipRuptureSizePlausibilityFilter.java
@@ -1,0 +1,42 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
+
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityResult;
+
+/**
+ * Used in MixedRuptureSetBuilder. Ensures that jumps can only go to and from the top row of a subduction cluster.
+ * <p>
+ * USed to restrict joint ruptures are at least a certain size.
+ * Should probably only be kept for the duration of the experimental joint rupture phase.
+ */
+public class DownDipRuptureSizePlausibilityFilter implements PlausibilityFilter {
+    @Override
+    public PlausibilityResult apply(ClusterRupture rupture, boolean verbose) {
+        double crustalSize = 0;
+        double downDipSize = 0;
+        for (FaultSubsectionCluster cluster : rupture.clusters) {
+            if (cluster.startSect instanceof DownDipFaultSection) {
+                downDipSize += cluster.subSects.size();
+            } else {
+                crustalSize += cluster.subSects.size();
+            }
+        }
+        if (crustalSize > 0 && downDipSize > 0 && (crustalSize < 25 || downDipSize < 600)) {
+            return PlausibilityResult.FAIL_HARD_STOP;
+        }
+        return PlausibilityResult.PASS;
+    }
+
+    @Override
+    public String getShortName() {
+        return "DownDipRuptureSizePlausibilityFilter";
+    }
+
+    @Override
+    public String getName() {
+        return "DownDipRuptureSizePlausibilityFilter";
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/DownDipSkipPlausibilityFilter.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/DownDipSkipPlausibilityFilter.java
@@ -1,0 +1,82 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityResult;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.UniqueRupture;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Wraps a PlausibilityFilter so that the filter skips downDip clusters but is applied to all crustal clusters.
+ * <p>
+ * Used in MixedRuptureSetBuilder
+ */
+public class DownDipSkipPlausibilityFilter implements PlausibilityFilter {
+
+    final PlausibilityFilter filter;
+
+    public DownDipSkipPlausibilityFilter(PlausibilityFilter filter) {
+        this.filter = filter;
+    }
+
+    protected PlausibilityResult apply(ClusterRupture parentRupture, List<FaultSubsectionCluster> rupture, boolean verbose) {
+        if (rupture.isEmpty()) {
+            return PlausibilityResult.PASS;
+        }
+        ClusterRupture clusterRupture = new PartialClusterRupture(parentRupture, rupture);
+        return filter.apply(clusterRupture, verbose);
+    }
+
+    @Override
+    public PlausibilityResult apply(ClusterRupture rupture, boolean verbose) {
+        if (Arrays.stream(rupture.clusters).anyMatch(c -> c.startSect instanceof DownDipFaultSection)) {
+            List<FaultSubsectionCluster> crustalRupture = new ArrayList<>();
+            for (FaultSubsectionCluster cluster : rupture.clusters) {
+                if (cluster.startSect instanceof DownDipFaultSection) {
+                    PlausibilityResult result = apply(rupture, crustalRupture, verbose);
+                    if (!result.canContinue()) {
+                        return result;
+                    }
+                    crustalRupture = new ArrayList<>();
+                } else {
+                    crustalRupture.add(cluster);
+                }
+            }
+            return apply(rupture, crustalRupture, verbose);
+        }
+        return filter.apply(rupture, verbose);
+    }
+
+    static class PartialClusterRupture extends ClusterRupture {
+
+        static ImmutableList<Jump> makeInternalJumps(ClusterRupture rupture, List<FaultSubsectionCluster> clusters) {
+            return ImmutableList.copyOf(
+                    rupture.internalJumps.stream().filter(
+                                    j -> clusters.contains(j.fromCluster) && clusters.contains(j.toCluster)).
+                            collect(Collectors.toList()));
+        }
+
+        public PartialClusterRupture(ClusterRupture rupture, List<FaultSubsectionCluster> clusters) {
+            super(clusters.toArray(new FaultSubsectionCluster[0]), makeInternalJumps(rupture, clusters), ImmutableMap.of(), UniqueRupture.forClusters(clusters.toArray(new FaultSubsectionCluster[0])), UniqueRupture.forClusters(clusters.toArray(new FaultSubsectionCluster[0])), true);
+        }
+    }
+
+    @Override
+    public String getShortName() {
+        return "DownDipSkipPlausibilityFilter";
+    }
+
+    @Override
+    public String getName() {
+        return "DownDipSkipPlausibilityFilter";
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/FishboneGenerator.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/FishboneGenerator.java
@@ -1,0 +1,296 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
+
+import com.bbn.openmap.geo.Geo;
+import com.bbn.openmap.geo.Rotation;
+import com.google.common.base.Preconditions;
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipFaultSubSectionCluster;
+import org.jfree.data.Range;
+import org.opensha.commons.data.function.DefaultXY_DataSet;
+import org.opensha.commons.data.function.XY_DataSet;
+import org.opensha.commons.geo.Location;
+import org.opensha.commons.geo.LocationUtils;
+import org.opensha.commons.gui.plot.*;
+import org.opensha.commons.util.DataUtils;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.faultSurface.RuptureSurface;
+
+import java.awt.*;
+import java.awt.geom.Point2D;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+/**
+ * Generates fishbone plots for joint ruptures. Experimental.
+ */
+public class FishboneGenerator {
+
+    public static class FishbonePlot {
+        public List<XY_DataSet> sectFuncs;
+        public List<PlotCurveCharacterstics> sectChars;
+
+        public FishbonePlot() {
+            sectFuncs = new ArrayList<>();
+            sectChars = new ArrayList<>();
+        }
+
+        public static void plotRotatedSection(FishboneGeometry.RotatedSection sect, List<XY_DataSet> funcs,
+                                             List<PlotCurveCharacterstics> chars, PlotCurveCharacterstics traceChar,
+                                             PlotCurveCharacterstics outlineChar) {
+            if (sect.section.getAveDip() < 90d) {
+                DefaultXY_DataSet xy = new DefaultXY_DataSet();
+                for (Geo g : sect.rotatedSurface) {
+                    xy.set(g.getLongitude(), g.getLatitude());
+                }
+                xy.set(xy.get(0));
+                funcs.add(xy);
+                chars.add(outlineChar);
+            }
+
+            DefaultXY_DataSet xy = new DefaultXY_DataSet();
+            for (Geo g : sect.rotatedTrace) {
+                xy.set(g.getLongitude(), g.getLatitude());
+            }
+            funcs.add(xy);
+            chars.add(traceChar);
+        }
+
+        public static void plotSection(FishboneGeometry.RotatedSection sect, List<XY_DataSet> funcs,
+                                       List<PlotCurveCharacterstics> chars, PlotCurveCharacterstics traceChar,
+                                       PlotCurveCharacterstics outlineChar) {
+            if (sect.section.getAveDip() < 90d) {
+                DefaultXY_DataSet xy = new DefaultXY_DataSet();
+                for (Location g : sect.surface) {
+                    xy.set(g.getLongitude(), g.getLatitude());
+                }
+                xy.set(xy.get(0));
+                funcs.add(xy);
+                chars.add(outlineChar);
+            }
+
+            DefaultXY_DataSet xy = new DefaultXY_DataSet();
+            for (Location g : sect.section.getFaultTrace()) {
+                xy.set(g.getLongitude(), g.getLatitude());
+            }
+            funcs.add(xy);
+            chars.add(traceChar);
+        }
+
+        protected void plotFishboneComponent(
+                FishboneGeometry.RotatedSection section,
+                PlotCurveCharacterstics traceChar) {
+            DefaultXY_DataSet xy = new DefaultXY_DataSet();
+            for (int s = 0; s < section.surface.size(); s++) {
+                Geo g = section.rotatedSurface.get(s);
+                Location l = section.surface.get(s);
+                xy.set((g.getLatitude() - section.getLatitudeOrigin()) * 111.1, -l.depth);
+            }
+            xy.set(xy.get(0));
+            sectFuncs.add(xy);
+            sectChars.add(traceChar);
+        }
+
+        public void plotFishbone(FishboneGeometry geometry) {
+
+            PlotCurveCharacterstics subductionChar = new PlotCurveCharacterstics(
+                    PlotLineType.SOLID, 1f, Color.RED);
+            PlotCurveCharacterstics outlineChar = new PlotCurveCharacterstics(
+                    PlotLineType.SOLID, 1f, Color.GRAY);
+
+            for (FishboneGeometry.RotatedSection section : geometry.sections) {
+                if (section.crossesPlane) {
+                    if (section.section instanceof DownDipFaultSection) {
+                        plotFishboneComponent(section, subductionChar);
+                    } else {
+                        plotFishboneComponent(section, outlineChar);
+                    }
+                }
+            }
+        }
+
+        public void plotDebugSlice(FishboneGeometry geometry) {
+            PlotCurveCharacterstics traceChar = new PlotCurveCharacterstics(
+                    PlotLineType.SOLID, 3f, Color.RED);
+            PlotCurveCharacterstics outlineChar = new PlotCurveCharacterstics(
+                    PlotLineType.SOLID, 1f, Color.GRAY);
+
+            PlotCurveCharacterstics greytraceChar = new PlotCurveCharacterstics(
+                    PlotLineType.SOLID, 3f, Color.GRAY);
+
+            for (FishboneGeometry.RotatedSection section : geometry.sections) {
+                plotSection(section, sectFuncs, sectChars, greytraceChar, outlineChar);
+            }
+
+            for (FishboneGeometry.RotatedSection section : geometry.sections) {
+                if (section.crossesPlane) {
+                    plotSection(section, sectFuncs, sectChars, traceChar, traceChar);
+                }
+            }
+        }
+
+        public static void plot(File outDior, String prefix, PlotSpec spec, boolean isLatLon) throws IOException {
+            DataUtils.MinMaxAveTracker latTrack = new DataUtils.MinMaxAveTracker();
+            DataUtils.MinMaxAveTracker lonTrack = new DataUtils.MinMaxAveTracker();
+            for (PlotElement xy : spec.getPlotElems()) {
+                for (Point2D pt : (XY_DataSet) xy) {
+                    latTrack.addValue(pt.getY());
+                    lonTrack.addValue(pt.getX());
+                }
+            }
+
+            double minLon = lonTrack.getMin();
+            double maxLon = lonTrack.getMax();
+            double minLat = latTrack.getMin();
+            double maxLat = latTrack.getMax();
+            if (isLatLon) {
+                maxLat += 0.05;
+                minLat -= 0.05;
+                maxLon += 0.05;
+                minLon -= 0.05;
+            } else {
+                double extra = (maxLat - minLat) * 0.05;
+                maxLat += extra;
+                minLat -= extra;
+                extra = (maxLon - minLon) * 0.05;
+                maxLon += extra;
+                minLon -= extra;
+            }
+            int width = 800;
+
+            Range xRange = new Range(minLon, maxLon);
+            Range yRange = new Range(minLat, maxLat);
+
+            HeadlessGraphPanel gp = PlotUtils.initHeadless();
+
+            gp.drawGraphPanel(spec, false, false, xRange, yRange);
+            PlotUtils.setAxisVisible(gp, true, true);
+            PlotUtils.setGridLinesVisible(gp, true, true);
+
+            PlotUtils.writePlots(outDior, prefix, gp, width, isLatLon, true, false, false);
+        }
+
+    }
+
+    public static class FishboneGeometry {
+        public Rotation rotation;
+        public double longitudePlane;
+        public List<RotatedSection> sections;
+        public double latitudeOrigin;
+
+        public FishboneGeometry(ClusterRupture rupture, int slice) {
+            FaultSection pivot = ((DownDipFaultSubSectionCluster) rupture.clusters[0]).getTraceSections().get(slice);
+            Location first = pivot.getFaultTrace().first();
+            Location last = pivot.getFaultTrace().last();
+
+            double azimuth = LocationUtils.azimuth(first, last);
+            this.rotation = new Rotation(new Geo(first.lat, first.lon), Math.toRadians(azimuth + 90));
+
+            Geo lastRot = rotation.rotate(new Geo(last.lat, last.lon));
+            this.longitudePlane = first.lon + ((lastRot.getLongitude() - first.lon) / 2);
+            this.latitudeOrigin = first.lat;
+            this.sections = rupture.buildOrderedSectionList().stream().
+                    map(RotatedSection::new).
+                    collect(Collectors.toList());
+        }
+
+        public Geo rotate(Location location) {
+            return rotation.rotate(new Geo(location.lat, location.lon));
+        }
+
+        public boolean crossesPlane(List<Geo> locations) {
+            boolean left = false;
+            boolean right = false;
+            for (Geo geo : locations) {
+                if (geo.getLongitude() < longitudePlane) {
+                    left = true;
+                } else if (geo.getLongitude() > longitudePlane) {
+                    right = true;
+                }
+                if (left && right) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public class RotatedSection {
+            public List<Geo> rotatedSurface;
+            public List<Geo> rotatedTrace;
+            public List<Location> surface;
+            public FaultSection section;
+            public boolean crossesPlane;
+
+            public RotatedSection(FaultSection section) {
+                this.section = section;
+                RuptureSurface surface = section.getFaultSurface(1, false, false);
+                this.surface = surface.getPerimeter();
+                rotatedSurface = this.surface.stream().
+                        map(FishboneGeometry.this::rotate).
+                        collect(Collectors.toList());
+                rotatedTrace = section.getFaultTrace().stream().
+                        map(FishboneGeometry.this::rotate).
+                        collect(Collectors.toList());
+                this.crossesPlane = crossesPlane(rotatedSurface);
+            }
+
+            public double getLatitudeOrigin() {
+                return FishboneGeometry.this.latitudeOrigin;
+            }
+
+        }
+    }
+
+    public static PlotSpec buildTopDownDebug(ClusterRupture rupture, int slice) {
+        Preconditions.checkArgument(rupture.clusters[0] instanceof DownDipFaultSubSectionCluster);
+
+        FishboneGeometry geometry = new FishboneGeometry(rupture, slice);
+
+        FishbonePlot overviewPlot = new FishbonePlot();
+        overviewPlot.plotDebugSlice(geometry);
+
+        return new PlotSpec(overviewPlot.sectFuncs, overviewPlot.sectChars, "fishbone debug", "Longitude", "Latitude");
+    }
+
+    public static void plotTopDownDebug(ClusterRupture rupture, int slice, File path, String prefix) throws IOException {
+        PlotSpec spec = buildTopDownDebug(rupture, slice);
+        FishbonePlot.plot(path, prefix, spec, true);
+    }
+
+    public static PlotSpec buildFishbone(ClusterRupture rupture, int slice) {
+        Preconditions.checkArgument(rupture.clusters[0] instanceof DownDipFaultSubSectionCluster);
+
+        FishboneGeometry geometry = new FishboneGeometry(rupture, slice);
+
+        FishbonePlot fishbonePlot = new FishbonePlot();
+        fishbonePlot.plotFishbone(geometry);
+
+        return new PlotSpec(fishbonePlot.sectFuncs, fishbonePlot.sectChars, "Fishbone", "Horizontal Distance (km)", "Elevation (km)");
+    }
+
+    public static void plotFishbone(ClusterRupture rupture, int slice, File path, String prefix) throws IOException {
+        PlotSpec spec = buildFishbone(rupture, slice);
+        FishbonePlot.plot(path, prefix, spec, false);
+    }
+
+    /**
+     * Generates a fishbone plot and a corresponding debug plot for each section in the topmost row of the subduction
+     * cluster.
+     * @param rupture a joint rupture
+     * @param path output directory
+     * @param prefix output file prefix
+     * @throws IOException
+     */
+    public static void plotAll(ClusterRupture rupture, File path, String prefix) throws IOException {
+        DownDipFaultSubSectionCluster cluster = (DownDipFaultSubSectionCluster) rupture.clusters[0];
+        for (int s = 0; s < cluster.getTraceSections().size(); s++) {
+            plotFishbone(rupture, s, path, prefix + s);
+            plotTopDownDebug(rupture, s, path, prefix +"debug"+ s);
+        }
+    }
+
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/JointRuptureBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/JointRuptureBuilder.java
@@ -1,0 +1,183 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
+
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipFaultSubSectionCluster;
+import nz.cri.gns.NZSHM22.opensha.ruptures.experimental.joint.ManipulatedClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Takes a rupture set with subduction and crustal ruptures and creates a new rupture set with joint ruptures.
+ * <p>
+ * Creates sequential joint rupture sets. In this case, sequential means that subduction clusters are part of a string
+ * of clusters. See JointRuptureBuilderParallel for creating more realistic ruptures.
+ */
+
+public class JointRuptureBuilder {
+    final List<ClusterRupture> ruptures;
+    final SectionDistanceAzimuthCalculator distAzCalc;
+
+    final int subductionMinCount;
+    final int subductionMaxCount;
+
+    // jumps from subduction to crustal
+    final OneToManyMap<Integer, Integer> jumps;
+
+    OneToManyMap<Integer, ClusterRupture> targetRuptures;
+
+    static FaultSection first(ClusterRupture rupture) {
+        return rupture.clusters[0].startSect;
+    }
+
+    // TODO make this work for subduction as well
+    static FaultSection last(ClusterRupture rupture) {
+        List<FaultSection> subSects = rupture.clusters[rupture.clusters.length - 1].subSects;
+        return subSects.get(subSects.size() - 1);
+    }
+
+    public JointRuptureBuilder(
+            List<Jump> possibleJumps,
+            List<ClusterRupture> ruptures,
+            SectionDistanceAzimuthCalculator distAzCalc,
+            int crustalMinCount,
+            int subductionMinCount,
+            int subductionMaxCount) {
+
+        this.ruptures = ruptures;
+        this.distAzCalc = distAzCalc;
+        this.subductionMinCount = subductionMinCount;
+        this.subductionMaxCount = subductionMaxCount;
+
+        // fill jumps with all jumps from subduction
+        this.jumps = new OneToManyMap<>();
+        possibleJumps.stream()
+                .filter(j -> j.fromSection instanceof DownDipFaultSection)
+                .forEach(j -> jumps.append(j.fromSection.getSectionId(), j.toSection.getSectionId()));
+        possibleJumps.stream()
+                .filter(j -> j.toSection instanceof DownDipFaultSection)
+                .forEach(j -> jumps.append(j.toSection.getSectionId(), j.fromSection.getSectionId()));
+
+
+        // fill targetRuptures with all non-pure-subduction ruptures that can be jumped to
+        targetRuptures = new OneToManyMap<>();
+        ruptures.stream()
+                .filter(r -> r.clusters.length > 1 || !(r.clusters[0] instanceof DownDipFaultSubSectionCluster))
+                .filter(r -> r.clusters[0].subSects.size() >= crustalMinCount)
+                .forEach(r -> {
+                    int startID = first(r).getSectionId();
+                    if (jumps.values.contains(startID)) {
+                        targetRuptures.append(startID, r);
+                    }
+
+                    int endId = last(r).getSectionId();
+                    if (jumps.values.contains(endId)) {
+                        targetRuptures.append(endId, r);
+                    }
+                });
+    }
+
+    public void stats(List<FaultSection> subSections) {
+        for (Integer from : jumps.keySet()) {
+            if (subSections.get(from) instanceof DownDipFaultSection) {
+                DownDipFaultSection fromSection = (DownDipFaultSection) subSections.get(from);
+
+                List<ClusterRupture> targets = new ArrayList<>();
+                for (Integer to : jumps.get(from)) {
+                    targets.addAll(targetRuptures.get(to));
+                }
+                System.out.println("" + fromSection.getParentSectionId() + ":" + fromSection.getSectionId() + " r " + fromSection.getRowIndex() + " count " + targets.size());
+            }
+        }
+    }
+
+    class JointJump {
+        final public int target;
+        final public ClusterRupture rupture;
+        final public ClusterRupture origin;
+
+        public JointJump(int target, ClusterRupture rupture) {
+            this.origin = null;
+            this.target = target;
+            this.rupture = rupture;
+        }
+
+        public JointJump(ClusterRupture origin, int target, ClusterRupture rupture) {
+            this.origin = origin;
+            this.target = target;
+            this.rupture = rupture;
+        }
+    }
+
+    protected List<ClusterRupture> joinRuptures(ClusterRupture subductionRupture) {
+        List<ClusterRupture> jointRuptures = new ArrayList<>();
+
+
+        jointRuptures.addAll(
+                jumps.get(first(subductionRupture).getSectionId()).stream()
+                        .flatMap(target -> targetRuptures.get(target).stream()
+                                .map(crustal -> new JointJump(target, crustal)))
+                        .parallel()
+                        .map(jump -> {
+                            if (first(jump.rupture).getSectionId() == jump.target) {
+                                // crustal = ManipulatedClusterRupture.reverse(crustal);
+                                return null;
+                            }
+                            return ManipulatedClusterRupture.join(jump.rupture, subductionRupture, distAzCalc);
+                        }).filter(Objects::nonNull).collect(Collectors.toList()));
+
+
+        List<ClusterRupture> candidates = new ArrayList<>(jointRuptures);
+        candidates.add(subductionRupture);
+
+        jointRuptures.addAll(
+                candidates.stream().flatMap(
+                                c -> jumps.get(last(c).getSectionId()).stream()
+                                        .flatMap(target -> targetRuptures.get(target).stream()
+                                                .map(crustal -> new JointJump(c, target, crustal)))
+
+
+                        ).parallel()
+                        .map(jump -> {
+                            try {
+                                if (first(jump.rupture).getSectionId() != jump.target) {
+                                    // crustal = ManipulatedClusterRupture.reverse(crustal);
+                                    return null;
+                                }
+                                return ManipulatedClusterRupture.join(jump.origin, jump.rupture, distAzCalc);
+                            } catch (IllegalStateException x) {
+                                // this can happen if we have created a circular rupture.
+                                // we need to find a more elegant way of detecting this.
+                                return null;
+                            }
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList())
+        );
+
+        return jointRuptures;
+    }
+
+    public List<ClusterRupture> build(int parentId) {
+
+        List<ClusterRupture> subductionRuptures = ruptures.stream()
+                .filter(r -> r.getTotalNumClusters() == 1)
+                .filter(r -> r.clusters[0].parentSectionID == parentId)
+                .filter(r -> r.clusters[0].subSects.size() >= subductionMinCount && r.clusters[0].subSects.size() <= subductionMaxCount)
+                .filter(r -> jumps.containsKey(first(r).getSectionId()) || jumps.containsKey(last(r).getSectionId()))
+                .collect(Collectors.toList());
+
+
+        System.out.println("Generating joint ruptures from " + subductionRuptures.size() + " subduction ruptures and " + jumps.values.size() + " jump targets for parent ID " + parentId);
+        List<ClusterRupture> jointRuptures = new ArrayList<>();
+        for (ClusterRupture rupture : subductionRuptures) {
+            jointRuptures.addAll(joinRuptures(rupture));
+        }
+        System.out.println("Generated " + jointRuptures.size() + " joint ruptures.");
+        return jointRuptures;
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/JointRuptureBuilderParallel.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/JointRuptureBuilderParallel.java
@@ -1,0 +1,344 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
+
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipFaultSubSectionCluster;
+import nz.cri.gns.NZSHM22.opensha.ruptures.experimental.joint.ManipulatedClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Takes a rupture set with subduction and crustal ruptures and creates a new rupture set with joint ruptures.
+ * <p>
+ * Can build parallel joint ruptures , i.e. joint ruptures with splays where the subduction and crustal ruptures run in parallel.
+ */
+public class JointRuptureBuilderParallel {
+    final List<ClusterRupture> ruptures;
+    final SectionDistanceAzimuthCalculator distAzCalc;
+
+    final int subductionMinCount;
+    final int subductionMaxCount;
+
+    // jumps from subduction to crustal
+    final OneToManyMap<Integer, Integer> jumps;
+
+    OneToManyMap<Integer, ClusterRupture> targetRuptures;
+
+    static FaultSection first(ClusterRupture rupture) {
+        return rupture.clusters[0].startSect;
+    }
+
+    // TODO make this work for subduction as well
+    static FaultSection last(ClusterRupture rupture) {
+        List<FaultSection> subSects = rupture.clusters[rupture.clusters.length - 1].subSects;
+        return subSects.get(subSects.size() - 1);
+    }
+
+    public static class JointJump extends Jump {
+        public ClusterRupture rupture;
+
+        public JointJump(
+                FaultSection fromSection,
+                FaultSubsectionCluster fromCluster,
+                FaultSection toSection,
+                FaultSubsectionCluster toCluster,
+                ClusterRupture toRupture,
+                double distance) {
+            super(fromSection, fromCluster, toSection, toCluster, distance);
+            this.rupture = toRupture;
+        }
+    }
+
+    public static Jump findJump(ClusterRupture subductionRupture,
+                                FaultSubsectionCluster targetCluster,
+                                SectionDistanceAzimuthCalculator distAzCalc,
+                                double maxJumpDist,
+                                double coverage
+    ) {
+        List<FaultSection> subductionSections = subductionRupture.buildOrderedSectionList();
+        List<Jump> jumps = new ArrayList<>();
+        int totalCount = 0;
+        for (FaultSection section : targetCluster.subSects) {
+            totalCount++;
+            int nearest = -1;
+            double distance = Double.MAX_VALUE;
+            for (int ss = 0; ss < subductionSections.size(); ss++) {
+                double candidateDist = distAzCalc.getDistance(subductionSections.get(ss), section);
+                if (candidateDist < distance) {
+                    nearest = ss;
+                    distance = candidateDist;
+                }
+            }
+            if (distance <= maxJumpDist) {
+                jumps.add(new Jump(subductionSections.get(nearest), subductionRupture.clusters[0], section, targetCluster, distance));
+            }
+        }
+
+        double actualCoverage = jumps.size() / (double) totalCount;
+        if (actualCoverage >= coverage) {
+            Jump jump = jumps.get(0);
+            // targetCluster.addConnection(new Jump(jump.toSection, jump.toCluster, jump.fromSection, jump.fromCluster, jump.distance));
+            return jump;
+        }
+
+        return null;
+    }
+
+    public boolean isCrustal(ClusterRupture rupture) {
+        return Arrays.stream(rupture.clusters).noneMatch(c -> c instanceof DownDipFaultSubSectionCluster);
+    }
+
+    public List<ClusterRupture> sortedCrustalRuptures(List<ClusterRupture> ruptures) {
+        return ruptures.stream().
+                filter(this::isCrustal).
+                sorted((a, b) -> Integer.compare(b.getTotalNumSects(), a.getTotalNumSects())).
+                collect(Collectors.toList());
+    }
+
+    /**
+     * Finds a jump between the two ruptures if enough sections of the crustalRupture are within maxJumpDist
+     *
+     * @param subductionRupture the subduction rupture
+     * @param crustalRupture    the crustal rupture
+     * @param distAzCalc        distAzCalc
+     * @param maxJumpDist       the max jump distance
+     * @param coverage          percentage of crustal sections that need to be within maxJumpDist
+     * @return
+     */
+    public static JointJump findJump(ClusterRupture subductionRupture,
+                                     ClusterRupture crustalRupture,
+                                     SectionDistanceAzimuthCalculator distAzCalc,
+                                     double maxJumpDist,
+                                     double coverage
+    ) {
+        List<FaultSection> subductionSections = subductionRupture.buildOrderedSectionList();
+        List<JointJump> jumps = new ArrayList<>();
+        int totalCount = 0;
+        for (FaultSubsectionCluster cluster : crustalRupture.clusters) {
+            for (FaultSection section : cluster.subSects) {
+                totalCount++;
+                int nearest = -1;
+                double distance = Double.MAX_VALUE;
+                for (int ss = 0; ss < subductionSections.size(); ss++) {
+                    double candidateDist = distAzCalc.getDistance(subductionSections.get(ss), section);
+                    if (candidateDist < distance) {
+                        nearest = ss;
+                        distance = candidateDist;
+                    }
+                }
+                if (distance <= maxJumpDist) {
+                    jumps.add(new JointJump(subductionSections.get(nearest), subductionRupture.clusters[0], section, cluster, crustalRupture, distance));
+                }
+            }
+        }
+
+        double actualCoverage = jumps.size() / (double) totalCount;
+        if (actualCoverage >= coverage) {
+
+            return jumps.get(0);
+        }
+
+        return null;
+    }
+
+    public static List<Jump> findAllJumps(ClusterRupture nucleation, List<FaultSubsectionCluster> targetClusters, SectionDistanceAzimuthCalculator distAzCalc) {
+//        ClusterRupture nucleation = ruptures.get(97653);
+
+        return targetClusters.parallelStream().
+                map(cluster -> findJump(nucleation, cluster, distAzCalc, 5, 0.9)).
+                filter(Objects::nonNull).
+                collect(Collectors.toList());
+    }
+
+    static ClusterRupture grow(ClusterRupture main, Set<FaultSubsectionCluster> connectedClusters, FaultSubsectionCluster fromCluster) {
+        Optional<Jump> optionalJump = fromCluster.getConnections().stream().
+                filter(j -> connectedClusters.contains(j.toCluster)).
+                filter(j -> !main.contains(j.toSection)).
+                findAny();
+        if (optionalJump.isEmpty()) {
+            return main;
+        }
+        Jump jump = optionalJump.get();
+        ClusterRupture newMain = main.take(jump);
+        return grow(newMain, connectedClusters, jump.toCluster);
+    }
+
+    static ClusterRupture growSplay(ClusterRupture nucleation, Set<FaultSubsectionCluster> connectedClusters, Jump jump) {
+        ClusterRupture main = nucleation.take(jump);
+        return grow(main, connectedClusters, jump.toCluster);
+    }
+
+    public static List<ClusterRupture> makeSplays(ClusterRupture nucleation, List<FaultSubsectionCluster> targetClusters, SectionDistanceAzimuthCalculator distAzCalc) {
+        List<Jump> jumps = findAllJumps(nucleation, targetClusters, distAzCalc);
+        List<ClusterRupture> result = new ArrayList<>();
+
+        Set<FaultSubsectionCluster> connectedClusters = jumps.stream().map(j -> j.toCluster).collect(Collectors.toSet());
+
+        result.add(growSplay(nucleation, connectedClusters, jumps.get(0)));
+        result.add(growSplay(nucleation, connectedClusters, jumps.get(10)));
+        result.add(growSplay(nucleation, connectedClusters, jumps.get(50)));
+        // result.add(growSplay(nucleation, connectedClusters, jumps.get(100)));
+
+        //result.add(nucleation.take(jumps.get(0)));
+        return result;
+    }
+
+    List<ClusterRupture> crustalRuptures;
+
+    public JointRuptureBuilderParallel(List<ClusterRupture> ruptures, SectionDistanceAzimuthCalculator distAzCalc) {
+        this.ruptures = ruptures;
+        this.distAzCalc = distAzCalc;
+        crustalRuptures = sortedCrustalRuptures(ruptures);
+        subductionMaxCount = 0;
+        subductionMinCount = 0;
+        jumps = null;
+    }
+
+    public ClusterRupture makeRuptureSplay(ClusterRupture nucleation, double maxJumpDist, int maxSplayCount) {
+        System.out.println("make splay");
+        int splayCount = 0;
+        ClusterRupture result = nucleation;
+        Set<Integer> crustalSections = new HashSet<>();
+        for (ClusterRupture crustalRupture : crustalRuptures) {
+            List<Integer> sectionIds = crustalRupture.buildOrderedSectionList().stream().map(FaultSection::getSectionId).collect(Collectors.toList());
+            boolean skip = false;
+            for (Integer id : sectionIds) {
+                if (crustalSections.contains(id)) {
+                    skip = true;
+                    break;
+                }
+            }
+            if (skip) {
+                continue;
+            }
+            Jump jump = findJump(nucleation, crustalRupture, distAzCalc, maxJumpDist, 0.9);
+            if (jump != null) {
+                result = ManipulatedClusterRupture.splay(result, crustalRupture, jump);
+                crustalSections.addAll(sectionIds);
+                splayCount++;
+                if (splayCount >= maxSplayCount) {
+                    return result;
+                }
+            }
+        }
+        return result;
+    }
+
+    public JointRuptureBuilderParallel(
+            List<Jump> possibleJumps,
+            List<ClusterRupture> ruptures,
+            SectionDistanceAzimuthCalculator distAzCalc,
+            int crustalMinCount,
+            int subductionMinCount,
+            int subductionMaxCount) {
+
+        this.ruptures = ruptures;
+        this.distAzCalc = distAzCalc;
+        this.subductionMinCount = subductionMinCount;
+        this.subductionMaxCount = subductionMaxCount;
+
+        // fill jumps with all jumps from subduction
+        this.jumps = new OneToManyMap<>();
+        possibleJumps.stream()
+                .filter(j -> j.fromSection instanceof DownDipFaultSection)
+                .forEach(j -> jumps.append(j.fromSection.getSectionId(), j.toSection.getSectionId()));
+        possibleJumps.stream()
+                .filter(j -> j.toSection instanceof DownDipFaultSection)
+                .forEach(j -> jumps.append(j.toSection.getSectionId(), j.fromSection.getSectionId()));
+
+
+        // fill targetRuptures with all non-pure-subduction ruptures that can be jumped to
+        targetRuptures = new OneToManyMap<>();
+        ruptures.stream()
+                .filter(r -> r.clusters.length > 1 || !(r.clusters[0] instanceof DownDipFaultSubSectionCluster))
+                .filter(r -> r.clusters[0].subSects.size() >= crustalMinCount)
+                .forEach(r -> {
+                    for (FaultSection section : r.buildOrderedSectionList()) {
+                        if (jumps.values.contains(section.getSectionId())) {
+                            targetRuptures.append(section.getSectionId(), r);
+                        }
+                    }
+                });
+    }
+
+    public void stats(List<FaultSection> subSections) {
+        for (Integer from : jumps.keySet()) {
+            if (subSections.get(from) instanceof DownDipFaultSection) {
+                DownDipFaultSection fromSection = (DownDipFaultSection) subSections.get(from);
+
+                List<ClusterRupture> targets = new ArrayList<>();
+                for (Integer to : jumps.get(from)) {
+                    targets.addAll(targetRuptures.get(to));
+                }
+                System.out.println("" + fromSection.getParentSectionId() + ":" + fromSection.getSectionId() + " r " + fromSection.getRowIndex() + " count " + targets.size());
+            }
+        }
+    }
+
+    //    protected List<ClusterRupture> joinRuptures(ClusterRupture subductionRupture) {
+//        List<ClusterRupture> jointRuptures = new ArrayList<>();
+//
+//
+//        if (subductionRupture.getTotalNumSects() <= 6) {
+//            DownDipFaultSubSectionCluster cluster = (DownDipFaultSubSectionCluster) subductionRupture.clusters[0];
+//            int topRow = cluster.ddSections.get(0).getRowIndex();
+//            for (DownDipFaultSection section : cluster.ddSections) {
+//                if (section.getRowIndex() == topRow) {
+//                    List<Integer> candidates = jumps.get(section.getSectionId());
+//                    for (Integer candidate : candidates) {
+//                        for (ClusterRupture target : targetRuptures.get(candidate)) {
+////                    if(target.getTotalNumSects() > (subductionRupture.getTotalNumSects() * 5)) {
+////                        Jump jump = new Jump(section, cluster, )
+////                    }
+////                        }
+//                    }
+//
+//                }
+//            }
+//
+//            jointRuptures.addAll(
+//                    jumps.get(first(subductionRupture).getSectionId()).stream()
+//                            .flatMap(target -> targetRuptures.get(target).stream()
+//                                    .map(crustal -> new JointJump(target, crustal)))
+//                            .parallel()
+//                            .map(jump -> {
+//                                if (first(jump.rupture).getSectionId() == jump.target) {
+//                                    // crustal = ManipulatedClusterRupture.reverse(crustal);
+//                                    return null;
+//                                }
+//                                return ManipulatedClusterRupture.join(jump.rupture, subductionRupture, distAzCalc);
+//                            }).filter(Objects::nonNull).collect(Collectors.toList()));
+//
+//
+//            List<ClusterRupture> candidates = new ArrayList<>(jointRuptures);
+//            candidates.add(subductionRupture);
+//
+//
+//            return jointRuptures;
+//        }
+//
+//        public List<ClusterRupture> build ( int parentId){
+//
+//            List<ClusterRupture> subductionRuptures = ruptures.stream()
+//                    .filter(r -> r.getTotalNumClusters() == 1)
+//                    .filter(r -> r.clusters[0].parentSectionID == parentId)
+//                    .filter(r -> r.clusters[0].subSects.size() >= subductionMinCount && r.clusters[0].subSects.size() <= subductionMaxCount)
+//                    .filter(r -> jumps.containsKey(first(r).getSectionId()) || jumps.containsKey(last(r).getSectionId()))
+//                    .collect(Collectors.toList());
+//
+//
+//            System.out.println("Generating joint ruptures from " + subductionRuptures.size() + " subduction ruptures and " + jumps.values.size() + " jump targets for parent ID " + parentId);
+//            List<ClusterRupture> jointRuptures = new ArrayList<>();
+//            for (ClusterRupture rupture : subductionRuptures) {
+//                jointRuptures.addAll(joinRuptures(rupture));
+//            }
+//            System.out.println("Generated " + jointRuptures.size() + " joint ruptures.");
+//            return jointRuptures;
+//        }
+//    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedGrowingStrategy.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedGrowingStrategy.java
@@ -1,6 +1,7 @@
-package nz.cri.gns.NZSHM22.opensha.ruptures;
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
 import com.google.common.base.Preconditions;
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.RuptureGrowingStrategy;
 import org.opensha.sha.faultSurface.FaultSection;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedPlausibleClusterConnectionStrategy.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedPlausibleClusterConnectionStrategy.java
@@ -1,5 +1,6 @@
-package nz.cri.gns.NZSHM22.opensha.ruptures;
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedPlausibleClusterConnectionStrategy.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedPlausibleClusterConnectionStrategy.java
@@ -17,6 +17,8 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Drop-in replacement for PlausibleClusterConnectionStrategy that is more efficient when subduction faults are
  * present.
+ * The main reason this extends PlausibleClusterConnectionStrategy rather than ClusterConnectionStrategy is that this
+ * way we can call buildPossibleConnections(). It's a hack :-(
  * PlausibleClusterConnectionStrategy will vet a possible jump by looking at permutations on the target fault that
  * do not make sense for subduction faults and are magnitudes more expensive at the same time. These permutations
  * do not take into account the DownDipPermutationStrategy and any of its filters.

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedRuptureSetBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedRuptureSetBuilder.java
@@ -1,4 +1,4 @@
-package nz.cri.gns.NZSHM22.opensha.ruptures;
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
@@ -7,6 +7,8 @@ import nz.cri.gns.NZSHM22.opensha.calc.SimplifiedScalingRelationship;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.FaultRegime;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_FaultModels;
 import nz.cri.gns.NZSHM22.opensha.faults.FaultSectionList;
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import nz.cri.gns.NZSHM22.opensha.ruptures.NZSHM22_AbstractRuptureSetBuilder;
 import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipConstraint;
 import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipPermutationStrategy;
 import org.dom4j.DocumentException;
@@ -39,8 +41,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class MixedRuptureSetBuilder extends NZSHM22_AbstractRuptureSetBuilder {
 

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/OneToManyMap.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/OneToManyMap.java
@@ -1,0 +1,30 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.*;
+
+public class OneToManyMap<K, V> extends HashMap<K, List<V>> {
+
+    Set<V> values = new HashSet<>();
+
+    public void append(K key, V value) {
+        compute(key, (k, v) -> {
+            if (v == null) {
+                v = new ArrayList<>();
+            }
+            v.add(value);
+            return v;
+        });
+        values.add(value);
+    }
+
+    @Override
+    public List<V> get(Object key) {
+        List<V> result = super.get(key);
+        if (result == null) {
+            return ImmutableList.of();
+        }
+        return result;
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/joint/JointRupturePostProcessor.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/joint/JointRupturePostProcessor.java
@@ -1,0 +1,367 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental.joint;
+
+import com.google.common.base.Preconditions;
+import nz.cri.gns.NZSHM22.opensha.calc.SimplifiedScalingRelationship;
+import nz.cri.gns.NZSHM22.opensha.ruptures.experimental.FishboneGenerator;
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipFaultSubSectionCluster;
+import nz.cri.gns.NZSHM22.opensha.ruptures.experimental.JointRuptureBuilderParallel;
+import org.dom4j.DocumentException;
+import org.opensha.commons.geo.Location;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RupCartoonGenerator;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Can read ruptures from an existing rupture set that contains subduction and crustal ruptures and
+ * combines them into joint ruptures.
+ * Experimental.
+ */
+public class JointRupturePostProcessor {
+
+    String rupturesFile = "C:\\Users\\user\\GNS\\nzshm-opensha\\TEST\\ruptures\\rupset-disjointed.zip";
+    double maxJumpDistance = 5;
+    int crustalMinCount = 2;
+    int subductionMinCount = 1;
+    int subductionMaxCount = 6;
+
+    List<ClusterRupture> ruptures;
+    List<FaultSection> subSections;
+    Set<Integer> subductionParents;
+
+    SectionDistanceAzimuthCalculator distCalc;
+
+    List<FaultSubsectionCluster> crustalClusters;
+    List<FaultSubsectionCluster> subductionClusters;
+
+    public JointRupturePostProcessor() {
+    }
+
+    /**
+     * Takes a list of subsections and rebuilds the parent faults as clusters.
+     * Creates separate lists for crustal and subduction faults.
+     * @param subSections
+     */
+    protected void makeParentClusters(List<FaultSection> subSections) {
+        crustalClusters = new ArrayList<>();
+        subductionClusters = new ArrayList<>();
+
+        int parentId = subSections.get(0).getParentSectionId();
+        boolean crustal = !(subSections.get(0) instanceof DownDipFaultSection);
+        List<FaultSection> clusterSections = new ArrayList<>();
+        for (FaultSection section : subSections) {
+            if (parentId != section.getParentSectionId()) {
+                if (crustal) {
+                    crustalClusters.add(new FaultSubsectionCluster(clusterSections));
+                } else {
+                    subductionClusters.add(new DownDipFaultSubSectionCluster(clusterSections));
+                }
+                parentId = section.getParentSectionId();
+                crustal = !(section instanceof DownDipFaultSection);
+                clusterSections = new ArrayList<>();
+            }
+            clusterSections.add(section);
+        }
+        if (crustal) {
+            crustalClusters.add(new FaultSubsectionCluster(clusterSections));
+        } else {
+            subductionClusters.add(new DownDipFaultSubSectionCluster(clusterSections));
+        }
+    }
+
+    /**
+     * adds jumps between clusters if the shortest distance is less than maxJumpDistance
+     *
+     * @param clusters
+     * @param distAzCalc
+     * @param maxJumpDistance
+     */
+    public void addCrustalJumps(List<FaultSubsectionCluster> clusters, SectionDistanceAzimuthCalculator distAzCalc, double maxJumpDistance) {
+        for (FaultSubsectionCluster from : clusters) {
+            for (FaultSubsectionCluster to : clusters) {
+                if (from == to) {
+                    continue;
+                }
+                FaultSection last = from.subSects.get(from.subSects.size() - 1);
+                FaultSection first = to.subSects.get(0);
+                double distance = distAzCalc.getDistance(last.getSectionId(), first.getSectionId());
+                if (distance <= maxJumpDistance) {
+                    from.addConnection(new Jump(last, from, first, to, distance));
+                    //  to.addConnection(new Jump(first, to, last, from, distance));
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the shortest jump between the two clusters
+     *
+     * @param from
+     * @param to
+     * @return
+     */
+
+    protected Jump shortestJump(FaultSubsectionCluster from, FaultSubsectionCluster to) {
+        FaultSection a = null;
+        FaultSection b = null;
+        double dist = Double.MAX_VALUE;
+        // TODO make this more efficient by checking the boundary boxes
+        for (FaultSection fromS : from.subSects) {
+            for (FaultSection toS : to.subSects) {
+                double candidateDist = distCalc.getDistance(fromS, toS);
+                if (candidateDist < dist) {
+                    dist = candidateDist;
+                    a = fromS;
+                    b = toS;
+                }
+            }
+        }
+        return new Jump(a, from, b, to, dist);
+    }
+
+    /**
+     * Returns possible jumps from the from cluster to the clusters in the clusters list.
+     * @param from
+     * @param clusters
+     * @return
+     */
+    protected List<Jump> clusterJumps(FaultSubsectionCluster from, List<FaultSubsectionCluster> clusters) {
+        List<Jump> result = clusters.parallelStream().
+                map(c -> shortestJump(from, c)).
+                filter(j -> j.distance <= maxJumpDistance).
+                collect(Collectors.toList());
+        if (!result.isEmpty()) {
+            for (Jump j : result) {
+                System.out.println("from " + j.fromSection.getSectionId() + " to: " + j.toSection.getSectionId() + " d: " + j.distance + " rakes: " + j.fromSection.getAveRake() + ", " + j.toSection.getAveRake() + " dips: " + j.fromSection.getAveDip() + ", " + j.toSection.getAveDip());
+            }
+            List<Integer> ids = result.stream().map(j -> j.toSection.getSectionId()).collect(Collectors.toList());
+            List<Double> ds = result.stream().map(j -> j.distance).collect(Collectors.toList());
+            List<Double> rakes = result.stream().map(j -> j.toSection.getAveRake()).collect(Collectors.toList());
+            System.out.println("hello");
+        }
+        return result;
+    }
+
+    /**
+     * finds the shortest jumps between clusters
+     *
+     * @return
+     */
+    protected List<List<Jump>> clusterJumps() {
+        return subductionClusters.stream().map(c -> clusterJumps(c, crustalClusters)).collect(Collectors.toList());
+    }
+
+    /**
+     * Calculates the length of a cluster. Has special code for handling subduction clusters so that only the top row
+     * is counted towards length
+     *
+     * @param cluster a cluster
+     * @return the length of the cluster
+     */
+    private double calculateLength(FaultSubsectionCluster cluster) {
+
+        if (cluster.subSects.get(0) instanceof DownDipFaultSection) {
+            List<DownDipFaultSection> ddCluster = (List<DownDipFaultSection>) (List<?>) cluster.subSects;
+            int minRow = ddCluster.stream().mapToInt(DownDipFaultSection::getRowIndex).min().getAsInt();
+            return ddCluster.stream().filter(s -> s.getRowIndex() == minRow).mapToDouble(DownDipFaultSection::getTraceLength).sum();
+        }
+
+        return cluster.subSects.stream().mapToDouble(FaultSection::getTraceLength).sum();
+    }
+
+    private double calculateLength(ClusterRupture rupture) {
+        return Arrays.stream(rupture.clusters).mapToDouble(this::calculateLength).sum() * 1e3;
+    }
+
+    protected double[] buildLengths(List<ClusterRupture> ruptures) {
+        // we don't count splays yet
+        System.out.println("start length " + new Date());
+        double[] result = new double[ruptures.size()];
+
+        IntStream.range(0, ruptures.size()).parallel().forEach(r -> {
+            result[r] = calculateLength(ruptures.get(r));
+        });
+        System.out.println("end length " + new Date());
+
+        return result;
+    }
+
+    static boolean includes(List<FaultSection> rupture, int sectionId) {
+
+        for (FaultSection section : rupture) {
+            if (section.getSectionId() == sectionId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void load(String ruptureSetPath) throws IOException {
+        RuptureLoader ruptureLoader = new RuptureLoader();
+        FaultSystemRupSet rupSet = FaultSystemRupSet.load(new File(ruptureSetPath));
+        ruptureLoader.loadRuptures(rupSet);
+        this.ruptures = ruptureLoader.ruptures;
+        this.subSections = ruptureLoader.subSections;
+        this.subductionParents = ruptureLoader.subductionParents;
+//        ClusterRupture rupture = null;
+//        int size = Integer.MAX_VALUE;
+//        int ruptureId = -1;
+//        for (int r = 0; r < ruptures.size(); r++) {
+//            ClusterRupture candidate = ruptures.get(r);
+//            List<FaultSection> sections = candidate.buildOrderedSectionList();
+//            if (includes(sections, 2295) && includes(sections, 2268)) {
+//                if (size > sections.size()) {
+//                    rupture = candidate;
+//                    size = sections.size();
+//                    ruptureId = r;
+//                }
+//            }
+//        }
+//        SimpleGeoJsonBuilder builder = new SimpleGeoJsonBuilder();
+//        for (FaultSection section : rupture.buildOrderedSectionList()) {
+//            builder.addFaultSection(section);
+//        }
+//        builder.toJSON("/tmp/choseRupture.geojson");
+    }
+
+    public void buildRuptureSet() throws DocumentException, IOException {
+        load(rupturesFile);
+        System.out.println("Loaded ruptures: " + ruptures.size() + " sections: " + subSections.size());
+        makeParentClusters(subSections);
+        System.out.println("Crustal clusters: " + crustalClusters.size() + " subduction clusters: " + subductionClusters.size());
+
+        System.out.println("Calculating shortest jumps to subductions");
+
+        distCalc = new SectionDistanceAzimuthCalculator(subSections);
+
+
+        JointRuptureBuilderParallel jrbp = new JointRuptureBuilderParallel(ruptures, distCalc);
+        ClusterRupture splayCandidate = jrbp.makeRuptureSplay(ruptures.get(97653), 5, 3);
+
+        if (splayCandidate != null) {
+            RupCartoonGenerator.plotRupture(new File("/tmp/rupcartoons/"), "splays", splayCandidate, "splays galore", false, true);
+            FishboneGenerator.plotAll(splayCandidate, new File("/tmp/rupcartoons/"), "fishbone4");
+//            FishboneGenerator.plotTopDownDebug(splayCandidate, new File("/tmp/rupcartoons/"), "fishbone-debug");
+//            FishboneGenerator.plotFishbone(splayCandidate, new File("/tmp/rupcartoons/"), "fishbone3");
+        }
+
+        FaultSection firstSection = splayCandidate.clusters[0].subSects.get(0);
+        Preconditions.checkState(firstSection instanceof DownDipFaultSection);
+
+        Location a = firstSection.getFaultTrace().first();
+        Location b = firstSection.getFaultTrace().last();
+
+
+        addCrustalJumps(crustalClusters, distCalc, 0.5);
+
+        ruptures = JointRuptureBuilderParallel.makeSplays(ruptures.get(97653), crustalClusters, distCalc);
+
+//        List<List<Jump>> jumps = clusterJumps();
+        System.out.println("done");
+//
+//
+//        for (List<Jump> jumps1 : jumps) {
+//            for (Jump jump : jumps1) {
+//                System.out.println("parent " + jump.fromSection.getParentSectionId() + " section " + jump.fromSection.getSectionId() + " row " + ((DownDipFaultSection) jump.fromSection).getRowIndex());
+//            }
+//        }
+//
+//        for (int i = 0; i < jumps.size(); i++) {
+//            JointRuptureBuilder jointRuptureBuilder = new JointRuptureBuilder(
+//                    jumps.get(i),
+//                    ruptures,
+//                    distCalc,
+//                    crustalMinCount,
+//                    subductionMinCount,
+//                    subductionMaxCount
+//            );
+//            jointRuptureBuilder.stats(subSections);
+//            ruptures.addAll(jointRuptureBuilder.build(subductionClusters.get(i).parentSectionID));
+//        }
+//
+//        int printed = 0;
+
+        System.out.println("ruptures before filtering: " + ruptures.size());
+
+//        int sectionCount = 0;
+//
+//        ruptures = ruptures.stream().filter(rupture -> {
+//            int subCount = 0;
+//            for (FaultSubsectionCluster cluster : rupture.clusters) {
+//                if (cluster instanceof DownDipFaultSubSectionCluster) {
+//                    subCount++;
+//                }
+//            }
+//
+//            return subCount > 1;
+//        }).collect(Collectors.toList());
+//
+//        int maxCount = ruptures.parallelStream().mapToInt(ClusterRupture::getTotalNumSects).max().getAsInt();
+
+//        ruptures = ruptures.stream().filter(r -> r.getTotalNumSects() ==maxCount).collect(Collectors.toList());
+
+//            if(subCount > 1 && printed < 10) {
+//                RupCartoonGenerator.plotRupture(new File ("/tmp/rupcartoons/"), "rupture" + i, rupture, "Rupture " + i, false, true);
+//                System.out.println("yes! " + rupture.clusters.length);
+//                printed++;
+//            }
+
+
+        List<ClusterRupture> filteredRuptures = ruptures.stream().filter(rupture -> {
+            int pos = 0;
+            for (FaultSubsectionCluster cluster : rupture.clusters) {
+                if (cluster instanceof DownDipFaultSubSectionCluster && pos > 0 && pos < rupture.clusters.length - 1) {
+                    return true;
+                }
+                pos++;
+            }
+            return false;
+        }).collect(Collectors.toList());
+
+        System.out.println("ruptures with subduction in the middle: " + filteredRuptures.size());
+
+        if (!filteredRuptures.isEmpty()) {
+            RupCartoonGenerator.plotRupture(new File("/tmp/rupcartoons/"), "rupture", filteredRuptures.get(0), "Rupture ", false, true);
+        }
+        System.out.println(" Ruptures after filtering: " + ruptures.size());
+
+        SimplifiedScalingRelationship sr = new SimplifiedScalingRelationship();
+        sr.setupCrustal(4.2, 4.2);
+
+        System.out.println("building rupset");
+        FaultSystemRupSet rupSet = FaultSystemRupSet.builderForClusterRups(subSections, ruptures)
+                //FaultSystemRupSet.builderForClusterRups(ruptureLoader.subSections, ruptures)
+                .rupLengths(buildLengths(ruptures))
+                .forScalingRelationship(sr)
+//                        .slipAlongRupture(getSlipAlongRuptureModel())
+//                        .addModule(getLogicTreeBranch(FaultRegime.CRUSTAL))
+//                        .addModule(SectionDistanceAzimuthCalculator.archivableInstance(distAzCalc))
+                .build();
+        System.out.println("writing rupset to file");
+        rupSet.write(new File("/tmp/joint-splay1.zip"));
+
+//        NZSHM22_ReportPageGen reportPageGen = new NZSHM22_ReportPageGen();
+//        reportPageGen.setName("Combined")
+//                .setRuptureSet(rupSet)
+//                .setOutputPath("/tmp/reports/joinrupset")
+//            //    .setRuptureSet("/tmp/jointrupset.zip");
+//        ;
+//        reportPageGen.generateRupSetPage();
+    }
+
+    public static void main(String[] args) throws IOException, DocumentException {
+        JointRupturePostProcessor processor = new JointRupturePostProcessor();
+        processor.buildRuptureSet();
+
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/joint/ManipulatedClusterRupture.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/joint/ManipulatedClusterRupture.java
@@ -1,0 +1,141 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental.joint;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipFaultSubSectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.UniqueRupture;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Provides functionality to combine ruptures into a new rupture using join() and splay()
+ */
+public class ManipulatedClusterRupture extends ClusterRupture {
+
+    /**
+     * We need this class and this constructor because the super constructor it calls is protected.
+     *
+     * @param clusters
+     * @param internalJumps
+     * @param unique
+     */
+    public ManipulatedClusterRupture(FaultSubsectionCluster[] clusters, ImmutableList<Jump> internalJumps, UniqueRupture unique) {
+        super(clusters, internalJumps, ImmutableMap.of(), unique, unique, true);
+    }
+
+    public ManipulatedClusterRupture
+            (FaultSubsectionCluster[] clusters,
+             ImmutableList<Jump> internalJumps,
+             ImmutableMap<Jump, ClusterRupture> splays,
+             UniqueRupture unique,
+             UniqueRupture internalUnique) {
+        super(clusters, internalJumps, splays, unique, internalUnique, splays == null || splays.isEmpty());
+    }
+
+    static FaultSection first(FaultSubsectionCluster cluster) {
+        return cluster.startSect;
+    }
+
+    static FaultSection last(FaultSubsectionCluster cluster) {
+        if (cluster instanceof DownDipFaultSubSectionCluster) {
+            return ((DownDipFaultSubSectionCluster) cluster).last();
+        }
+        return cluster.subSects.get(cluster.subSects.size() - 1);
+    }
+
+    static ImmutableList<Jump> makeInternalJumps(
+            ClusterRupture ruptureA,
+            ClusterRupture ruptureB,
+            SectionDistanceAzimuthCalculator disAzCalc) {
+
+        List<Jump> jumps = new ArrayList<>();
+        jumps.addAll(ruptureA.internalJumps);
+
+        FaultSubsectionCluster fromCluster = ruptureA.clusters[ruptureA.clusters.length - 1];
+        FaultSection from = last(fromCluster);
+        FaultSubsectionCluster toCluster = ruptureB.clusters[0];
+        FaultSection to = first(toCluster);
+        double distance = disAzCalc.getDistance(from, to);
+        jumps.add(new Jump(from, fromCluster, to, toCluster, distance));
+
+        jumps.addAll(ruptureB.internalJumps);
+        return ImmutableList.copyOf(jumps);
+    }
+
+
+    /**
+     * Creates a new rupture by jumping from the last section of ruptureA to the first section of ruptureB
+     *
+     * @param ruptureA
+     * @param ruptureB
+     * @param disAzCalc
+     * @return
+     */
+
+    public static ManipulatedClusterRupture join(
+            ClusterRupture ruptureA,
+            ClusterRupture ruptureB,
+            SectionDistanceAzimuthCalculator disAzCalc) {
+
+        List<FaultSubsectionCluster> clusters = new ArrayList<>();
+        clusters.addAll(Arrays.asList(ruptureA.clusters));
+        clusters.addAll(Arrays.asList(ruptureB.clusters));
+        FaultSubsectionCluster[] clusterArray = clusters.toArray(new FaultSubsectionCluster[0]);
+
+        UniqueRupture unique = UniqueRupture.forClusters(clusterArray);
+        ImmutableList<Jump> internalJumps = makeInternalJumps(ruptureA, ruptureB, disAzCalc);
+
+        return new ManipulatedClusterRupture(clusterArray, internalJumps, unique);
+    }
+
+    /**
+     * Creates a new rupture by taking a splay jump
+     * OpenSHA only allows taking a jump to a cluster, not to a complete rupture.
+     *
+     * @param ruptureA
+     * @param ruptureB
+     * @param jump
+     * @return
+     */
+    public static ManipulatedClusterRupture splay(
+            ClusterRupture ruptureA,
+            ClusterRupture ruptureB,
+            Jump jump) {
+        ImmutableMap.Builder<Jump, ClusterRupture> splayBuilder = ImmutableMap.builder();
+        splayBuilder.putAll(ruptureA.splays);
+        ClusterRupture targetRupture = new ManipulatedClusterRupture(ruptureB.clusters, ruptureB.internalJumps, ruptureB.unique);
+        splayBuilder.put(jump, targetRupture);
+        ImmutableMap<Jump, ClusterRupture> newSplays = splayBuilder.build();
+        UniqueRupture newUnique = UniqueRupture.add(ruptureA.unique, ruptureB.unique);
+        return new ManipulatedClusterRupture(ruptureA.clusters, ruptureA.internalJumps, newSplays, newUnique, ruptureA.internalUnique);
+    }
+
+    /**
+     * Safely reverses ruptures that may have a subduction cluster.
+     *
+     * @param rupture
+     * @return
+     */
+    public static ClusterRupture reverse(ClusterRupture rupture) {
+        Preconditions.checkState(rupture.singleStrand, "Can only reverse single strand ruptures");
+
+        List<FaultSubsectionCluster> clusterList = Arrays.stream(rupture.clusters).map(FaultSubsectionCluster::reversed).collect(Collectors.toList());
+        Collections.reverse(clusterList);
+
+        List<Jump> jumps = rupture.internalJumps.stream().map(j -> new Jump(j.toSection, j.toCluster, j.fromSection, j.fromCluster, j.distance)).collect(Collectors.toList());
+        Collections.reverse(jumps);
+
+        return new ManipulatedClusterRupture(clusterList.toArray(new FaultSubsectionCluster[0]), ImmutableList.copyOf(jumps), rupture.unique);
+    }
+
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/joint/RuptureLoader.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/joint/RuptureLoader.java
@@ -1,0 +1,121 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental.joint;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipFaultSubSectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.modules.ClusterRuptures;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Loads a rupture set from an archive and restores subduction class like
+ * DownDipFaultSection and DownDipFaultSubSectionCluster
+ */
+public class RuptureLoader {
+
+    protected List<FaultSection> subSections;
+    protected Set<Integer> subductionParents;
+    protected List<ClusterRupture> ruptures;
+
+    public RuptureLoader() {
+    }
+
+    protected void makeSectionList(List<? extends FaultSection> sections) {
+        subductionParents = new HashSet<>();
+        Pattern pattern = Pattern.compile("; col: (\\d+), row: (\\d+)");
+        subSections = sections.stream().map(section -> {
+            Matcher m = pattern.matcher(section.getSectionName());
+            if (m.find()) {
+                DownDipFaultSection ddSection = new DownDipFaultSection();
+                ddSection.setFaultSectionPrefData(section);
+                ddSection.setColIndex(Integer.parseInt(m.group(1)));
+                ddSection.setRowIndex(Integer.parseInt(m.group(2)));
+                subductionParents.add(ddSection.getParentSectionId());
+
+                return ddSection;
+            }
+            return section;
+
+        }).collect(Collectors.toList());
+    }
+
+    protected FaultSubsectionCluster translateCluster(FaultSubsectionCluster origCluster) {
+        List<FaultSection> sections = origCluster.subSects.stream().map(s -> {
+            FaultSection section = subSections.get(s.getSectionId());
+            Preconditions.checkState(section.getSectionId() == s.getSectionId());
+            Preconditions.checkState(section.getParentSectionId() == s.getParentSectionId());
+            return section;
+        }).collect(Collectors.toList());
+
+        if (subductionParents.contains(origCluster.parentSectionID)) {
+            return new DownDipFaultSubSectionCluster(sections, List.of());
+        }
+        return new FaultSubsectionCluster(sections, List.of());
+    }
+
+    boolean clustersEqual(FaultSubsectionCluster ca, FaultSubsectionCluster cb) {
+        if (ca.subSects.size() != cb.subSects.size()) {
+            return false;
+        }
+        for (int i = 0; i < ca.subSects.size(); i++) {
+            if (ca.subSects.get(i).getSectionId() != cb.subSects.get(i).getSectionId()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected ClusterRupture translateRupture(ClusterRupture origRupture) {
+        List<FaultSubsectionCluster> clusters = Arrays.stream(origRupture.clusters).map(this::translateCluster).collect(Collectors.toList());
+
+        List<Jump> jumps = new ArrayList<>();
+
+        for (int i = 1; i < origRupture.clusters.length; i++) {
+            Jump origJump = origRupture.internalJumps.get(i - 1);
+            FaultSubsectionCluster origFromCluster = origJump.fromCluster;
+            FaultSubsectionCluster fromCluster = clusters.get(i - 1);
+            Preconditions.checkState(clustersEqual(origFromCluster, fromCluster));
+            FaultSubsectionCluster origToCluster = origJump.toCluster;
+            FaultSubsectionCluster toCluster = clusters.get(i);
+            Preconditions.checkState(clustersEqual(origToCluster, toCluster));
+
+            jumps.add(new Jump(
+                    subSections.get(origJump.fromSection.getSectionId()),
+                    fromCluster,
+                    subSections.get(origJump.toSection.getSectionId()),
+                    toCluster,
+                    origJump.distance));
+        }
+
+        return new ManipulatedClusterRupture(clusters.toArray(FaultSubsectionCluster[]::new), ImmutableList.copyOf(jumps), origRupture.unique);
+    }
+
+    /**
+     * Loads the ruptures from the specified file and ensures that DownDipFaultSubSectionCluster and
+     * DownDipFaultSection are used when appropriate.
+     *
+     * @param rupSet
+     * @throws IOException
+     */
+    public void loadRuptures(FaultSystemRupSet rupSet) throws IOException {
+
+        ClusterRuptures cRups = rupSet.getModule(ClusterRuptures.class);
+
+        makeSectionList(rupSet.getFaultSectionDataList());
+
+        ruptures = new ArrayList<>();
+        for (ClusterRupture rupture : cRups) {
+            ruptures.add(translateRupture(rupture));
+        }
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/util/NZSHM22_ReportPageGen.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/util/NZSHM22_ReportPageGen.java
@@ -23,6 +23,7 @@ public class NZSHM22_ReportPageGen {
     ReportPageGen.PlotLevel plotLevel = ReportPageGen.PlotLevel.FULL;
     List<AbstractRupSetPlot> plots = null;
     boolean fillSurfaces = false;
+    FaultSystemRupSet rupSet = null;
 
     public NZSHM22_ReportPageGen() {
     }
@@ -34,6 +35,11 @@ public class NZSHM22_ReportPageGen {
 
     public NZSHM22_ReportPageGen setSolution(String path) {
         this.solutionPath = path;
+        return this;
+    }
+
+    public NZSHM22_ReportPageGen setRuptureSet(FaultSystemRupSet rupSet) {
+        this.rupSet = rupSet;
         return this;
     }
 
@@ -180,7 +186,7 @@ public class NZSHM22_ReportPageGen {
             System.err.println("Warning: Execution environment has only " + available + " processors allocated. Report threading is disabled.");
         }
 
-        FaultSystemRupSet rupSet = FaultSystemRupSet.load(new File(solutionPath));
+        FaultSystemRupSet rupSet = this.rupSet != null ? this.rupSet : FaultSystemRupSet.load(new File(solutionPath));
         addNamedFaults(rupSet);
         ReportMetadata solMeta = new ReportMetadata(new RupSetMetadata(name, rupSet));
 

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedRuptureSetBuilderTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedRuptureSetBuilderTest.java
@@ -1,4 +1,4 @@
-package nz.cri.gns.NZSHM22.opensha.ruptures;
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
 import org.junit.Test;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
@@ -140,10 +141,15 @@ public class MixedRuptureSetBuilderTest {
         }, actual, 0.0000001);
     }
 
+    static class MockMixedRuptureSetBuilder extends MixedRuptureSetBuilder {
+        public MockMixedRuptureSetBuilder(List<ClusterRupture> ruptures) {
+            this.ruptures = ruptures;
+        }
+    }
+
     static MixedRuptureSetBuilder mockBuilder(ClusterRupture... ruptures) {
-        MixedRuptureSetBuilder builder = new MixedRuptureSetBuilder();
-        builder.ruptures = ImmutableList.copyOf(ruptures);
-        return builder;
+        return new MockMixedRuptureSetBuilder(ImmutableList.copyOf(ruptures));
+
     }
 
     static class MockRupture extends ClusterRupture {


### PR DESCRIPTION
Satisfies #323 

An experiment to create joint ruptures.

Includes
- `DownDipFaultSubSectionCluster` a subduction-specific cluster
- `RuptureLoader` loads ruptures from a rupture set and re-create classes such as `DownDipFaultSection` and `DownDipFaultSubSectionCluster`
- `ManipulatedClusterRupture` lets us merge existing ruptures in different ways
- `JointRuptureBuilder` can create sequential joint ruptures
- `JointRuptureBuilderParallel` can create parallel joint ruptures using splays
- `JointRupturePostProcessor` is the `main` class that drives the `JointRuptureBuilder` implementations
- `FishboneGenerator` is an experimental fishbone graph generator for joint ruptures
