### PR TITLE
move experimental joint rupture code to separate package

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_AbstractRuptureSetBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_AbstractRuptureSetBuilder.java
@@ -29,7 +29,7 @@ public abstract class NZSHM22_AbstractRuptureSetBuilder {
 	PlausibilityConfiguration plausibilityConfig;
 	
     protected FaultSectionList subSections;
-    List<ClusterRupture> ruptures;
+    protected List<ClusterRupture> ruptures;
     ClusterRuptureBuilder builder;
 
     File fsdFile = null;
@@ -37,11 +37,11 @@ public abstract class NZSHM22_AbstractRuptureSetBuilder {
     String downDipFaultName = null;
     NZSHM22_FaultModels faultModel = null;
 
-    int minSubSectsPerParent = 2; // 2 are required for UCERf3 azimuth calcs
+    protected int minSubSectsPerParent = 2; // 2 are required for UCERf3 azimuth calcs
     int minSubSections = 2; // New NZSHM22
 
     double maxSubSectionLength = 0.5; // maximum sub section length (in units of DDW)
-    int numThreads = Runtime.getRuntime().availableProcessors(); // use all available processors
+    protected int numThreads = Runtime.getRuntime().availableProcessors(); // use all available processors
 
 	protected RupSetScalingRelationship scalingRelationship = ScalingRelationships.SHAW_2009_MOD;
 	protected SlipAlongRuptureModels slipAlongRuptureModel = SlipAlongRuptureModels.UNIFORM;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedGrowingStrategy.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedGrowingStrategy.java
@@ -1,6 +1,7 @@
-package nz.cri.gns.NZSHM22.opensha.ruptures;
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
 import com.google.common.base.Preconditions;
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.RuptureGrowingStrategy;
 import org.opensha.sha.faultSurface.FaultSection;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedPlausibleClusterConnectionStrategy.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedPlausibleClusterConnectionStrategy.java
@@ -1,5 +1,6 @@
-package nz.cri.gns.NZSHM22.opensha.ruptures;
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedRuptureSetBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedRuptureSetBuilder.java
@@ -1,4 +1,4 @@
-package nz.cri.gns.NZSHM22.opensha.ruptures;
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
@@ -7,6 +7,8 @@ import nz.cri.gns.NZSHM22.opensha.calc.SimplifiedScalingRelationship;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.FaultRegime;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_FaultModels;
 import nz.cri.gns.NZSHM22.opensha.faults.FaultSectionList;
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
+import nz.cri.gns.NZSHM22.opensha.ruptures.NZSHM22_AbstractRuptureSetBuilder;
 import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipConstraint;
 import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipPermutationStrategy;
 import org.dom4j.DocumentException;
@@ -39,8 +41,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class MixedRuptureSetBuilder extends NZSHM22_AbstractRuptureSetBuilder {
 

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedRuptureSetBuilderTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/MixedRuptureSetBuilderTest.java
@@ -1,4 +1,4 @@
-package nz.cri.gns.NZSHM22.opensha.ruptures;
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import nz.cri.gns.NZSHM22.opensha.ruptures.DownDipFaultSection;
 import org.junit.Test;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
@@ -140,10 +141,15 @@ public class MixedRuptureSetBuilderTest {
         }, actual, 0.0000001);
     }
 
+    static class MockMixedRuptureSetBuilder extends MixedRuptureSetBuilder {
+        public MockMixedRuptureSetBuilder(List<ClusterRupture> ruptures) {
+            this.ruptures = ruptures;
+        }
+    }
+
     static MixedRuptureSetBuilder mockBuilder(ClusterRupture... ruptures) {
-        MixedRuptureSetBuilder builder = new MixedRuptureSetBuilder();
-        builder.ruptures = ImmutableList.copyOf(ruptures);
-        return builder;
+        return new MockMixedRuptureSetBuilder(ImmutableList.copyOf(ruptures));
+
     }
 
     static class MockRupture extends ClusterRupture {


### PR DESCRIPTION
We want to isolate experimental code better by having it use its own `experimental` package.