### PR TITLE
Set mag norm for a smooth starting solution

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
@@ -47,6 +47,7 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.Itera
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.GenerationFunctionType;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.NonnegativityConstraintType;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.CoolingScheduleType;
+import scratch.UCERF3.inversion.UCERF3InversionConfiguration;
 
 /**
  * @author chrisbc
@@ -682,6 +683,8 @@ public abstract class NZSHM22_AbstractInversionRunner {
 	 * @throws DocumentException
 	 */
 	public FaultSystemSolution runInversion() throws IOException, DocumentException {
+
+		UCERF3InversionConfiguration.setMagNorm(8.1);
 
 		configure();
 		validateConfig();


### PR DESCRIPTION
[These changes](https://github.com/opensha/opensha/commit/c15148d494a27de68940974edacb879cb614345a) to `UCERF3InversionConfiguration.getSmoothStartingSolution()`  [have been moved](https://github.com/opensha/opensha/commit/c99795048cf49e8f692948dc71140eae27cfcb4c) from our branch to `opensha` so now we need to configure this value explicitly instead.

The `fix/rup-normalization-2024` branch on our opensha fork has already been amended.