### PR TITLE
[343] log inversion state

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/LoggingCompletionCriteria.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/LoggingCompletionCriteria.java
@@ -1,0 +1,229 @@
+package nz.cri.gns.NZSHM22.opensha.inversion;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.InversionState;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.CompletionCriteria;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.text.DecimalFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Can be used to wrap a CompletionCriteria to log all InversionState instances that are passed in.
+ * Note that this will not work as a sub CompletionCriteria if the inner criteria relies on iteration count.
+ * Logs will be broken up into zip files.
+ */
+public class LoggingCompletionCriteria implements CompletionCriteria, Closeable {
+
+    protected final CompletionCriteria innerCriteria;
+
+    protected InversionStateLog solutionLog;
+
+    /**
+     * Creates a new LoggingCompletionCriteria
+     *
+     * @param innerCriteria the isSatisfied() method will be forwarded to the innerCriteria
+     * @param basePath      a path to a folder. Does not need to exist. All log files will be stored in this folder.
+     * @param maxMB         log files will be split up if they reach this size (uncompressed)
+     * @throws IOException
+     */
+    public LoggingCompletionCriteria(CompletionCriteria innerCriteria, String basePath, int maxMB) throws IOException {
+        this.innerCriteria = innerCriteria;
+        this.solutionLog = new InversionStateLog(basePath, maxMB);
+
+        Files.createDirectories(new File(basePath).toPath());
+    }
+
+    @Override
+    public boolean isSatisfied(InversionState state) {
+
+        solutionLog.log(state);
+
+        return innerCriteria.isSatisfied(state);
+    }
+
+    @Override
+    public void close() throws IOException {
+        solutionLog.close();
+    }
+
+    protected static class InversionStateLog implements Closeable {
+
+        MultiZipLog log;
+
+        public InversionStateLog(String basePath, int maxMB) {
+            log = new MultiZipLog(basePath, "inversionState", ((long) maxMB) * 1024 * 1024);
+            log.addHeader("meta", "iterations,elapsedTimeMillis,numPerturbsKept,numWorseValuesKept,numNonZero\n");
+        }
+
+        public void log(InversionState state) {
+            log.nextIndex(state.iterations);
+
+            String meta = state.iterations + ","
+                    + state.elapsedTimeMillis + ","
+                    + state.numPerturbsKept + ","
+                    + state.numWorseValuesKept + ","
+                    + state.numNonZero + "\n";
+
+            log.log("meta", meta);
+            log.log("solution", state.bestSolution);
+            log.log("energy", state.energy);
+            log.log("misfits", state.misfits);
+            log.log("misfits_ineq", state.misfits_ineq);
+        }
+
+        @Override
+        public void close() throws IOException {
+            log.close();
+        }
+    }
+
+    /**
+     * Can be used log multiple streams at once. Streams are synchronized by index and stored together in a zip file.
+     * The zip file will be broken up if the uncompressed data takes up more than a specified sized.
+     */
+    static class MultiZipLog implements Closeable {
+
+        String fileName;
+        long maxBytes;
+
+        long bytes;
+        long startLine;
+        long currentLine;
+
+        Map<String, List<byte[]>> cache;
+
+        Map<String, String> headers = new HashMap<>();
+
+        /**
+         * Creates a new MultiZipLog
+         *
+         * @param basePath a folder that the log files will be stored in
+         * @param fileName a file name prefix for the log files
+         * @param maxBytes zip files will be split if their uncompressed size exceeds this limit
+         */
+        public MultiZipLog(String basePath, String fileName, long maxBytes) {
+            try {
+                Files.createDirectories(new File(basePath).toPath());
+                this.fileName = new File(basePath, fileName).getAbsolutePath();
+                this.maxBytes = maxBytes;
+            } catch (IOException x) {
+                throw new RuntimeException(x);
+            }
+        }
+
+        public void addHeader(String file, String header) {
+            headers.put(file, header);
+        }
+
+        static DecimalFormat fmt = new DecimalFormat("0.###E0");
+
+        public static String format(double value) {
+
+            if (value == 0) {
+                return "0";
+            }
+
+            String a = value + "";
+
+            if (Double.isInfinite(value) || Double.isNaN(value)) {
+                return a;
+            }
+
+            // writing it like this because using regex functions here double the runtime for inmversion
+            if (a.charAt(0) == '0' && a.charAt(1) == '.') {
+                a = a.substring(1);
+            }
+
+            if (a.length() < 5) {
+                return a;
+            }
+
+            String b = fmt.format(value);
+            if (b.charAt(b.length() - 2) == 'E' && b.charAt(b.length() - 1) == '0') {
+                b = b.substring(0, b.length() - 2);
+            }
+
+            if (b.length() < a.length()) {
+                return b;
+            }
+            return a;
+        }
+
+        static byte[] getBytes(double[] data) {
+            String line = "\n";
+
+            if (data != null) {
+                line = Arrays.stream(data).mapToObj(MultiZipLog::format).collect(Collectors.joining(",")) + "\n";
+            }
+            return line.getBytes();
+        }
+
+        public void log(String file, double[] data) {
+            byte[] bytes = getBytes(data);
+            log(file, bytes);
+        }
+
+        public void log(String file, String data) {
+            byte[] bytes = data.getBytes();
+            log(file, bytes);
+        }
+
+        public void nextIndex(long line) {
+            if (bytes >= maxBytes) {
+                writeToFile();
+                cache = null;
+            }
+
+            if (cache == null) {
+                cache = new HashMap<>();
+                bytes = 0;
+                startLine = line;
+            }
+            currentLine = line;
+        }
+
+        public void log(String file, byte[] data) {
+            bytes += data.length;
+            List<byte[]> list = cache.computeIfAbsent(file, k -> new ArrayList<>());
+            list.add(data);
+        }
+
+        public void writeToFile() {
+            try {
+                FileOutputStream fout = new FileOutputStream(fileName + "[" + startLine + "-" + currentLine + "].zip");
+                ZipOutputStream zout = new ZipOutputStream(fout);
+                zout.setLevel(9);
+
+                for (String file : cache.keySet()) {
+                    List<byte[]> data = cache.get(file);
+                    String header = headers.get(file);
+                    zout.putNextEntry(new ZipEntry(file + ".csv"));
+                    if (header != null) {
+                        zout.write(header.getBytes());
+                    }
+                    for (byte[] line : data) {
+                        zout.write(line);
+                    }
+                    zout.closeEntry();
+                }
+
+                zout.finish();
+                zout.close();
+            } catch (IOException x) {
+                throw new RuntimeException(x);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (cache != null) {
+                writeToFile();
+                cache = null;
+            }
+        }
+    }
+}

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/LoggingCompletionCriteriaTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/LoggingCompletionCriteriaTest.java
@@ -1,0 +1,81 @@
+package nz.cri.gns.NZSHM22.opensha.inversion;
+
+import org.junit.Test;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.junit.Assert.*;
+
+public class LoggingCompletionCriteriaTest {
+
+    static String format(double value) {
+        return LoggingCompletionCriteria.MultiZipLog.format(value);
+    }
+
+    @Test
+    public void testFormat() {
+
+        assertEquals("0", format(0));
+        assertEquals("1.0", format(1));
+        assertEquals("10.0", format(10));
+        assertEquals("1E6", format(1000000));
+        assertEquals(".001", format(0.001));
+        assertEquals("1E-4", format(0.0001));
+        assertEquals("1E-6", format(0.000001));
+        assertEquals("1.235", format(1.23456));
+        assertEquals("1.235E3", format(1234.5678));
+
+    }
+
+    static String getFile(File path, String csvFile) throws IOException {
+        ZipFile zip = new ZipFile(path);
+        ZipEntry entry = zip.getEntry(csvFile);
+        InputStream in = zip.getInputStream(entry);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+        String data = reader.lines().collect(Collectors.joining("\n"));
+        zip.close();
+        return data;
+    }
+
+    @Test
+    public void testLog() throws IOException {
+        String headerFile = "withHeader";
+        String arrayFile = "arrayFile";
+
+        File tempDir = Files.createTempDirectory("zipLog").toFile();
+
+        LoggingCompletionCriteria.MultiZipLog log = new LoggingCompletionCriteria.MultiZipLog(
+                tempDir.getAbsolutePath(),
+                "testLog",
+                30);
+        log.addHeader(headerFile, "a,b,c\n");
+
+        log.nextIndex(0);
+        log.log(headerFile, new double[]{1, 2, 3});
+        log.log(arrayFile, new double[]{4, 5, 6});
+
+        log.nextIndex(1);
+        log.log(headerFile, "a,b,c\n");
+        log.log(arrayFile, new double[]{7, 8, 9});
+
+        log.nextIndex(2);
+        log.log(headerFile, "d,e,f\n");
+        log.log(arrayFile, new double[]{10, 11, 12});
+
+        log.close();
+
+        String actual = getFile(new File(tempDir, "testLog[0-1].zip"), headerFile + ".csv");
+        assertEquals("a,b,c\n1.0,2.0,3.0\na,b,c", actual);
+        actual = getFile(new File(tempDir, "testLog[2-2].zip"), headerFile + ".csv");
+        assertEquals("a,b,c\nd,e,f", actual);
+
+        actual = getFile(new File(tempDir, "testLog[0-1].zip"), arrayFile + ".csv");
+        assertEquals("4.0,5.0,6.0\n7.0,8.0,9.0", actual);
+        actual = getFile(new File(tempDir, "testLog[2-2].zip"), arrayFile + ".csv");
+        assertEquals("10.0,11.0,12.0", actual);
+    }
+}


### PR DESCRIPTION
This PR provides a new inversion runner that allows users to log the inversion state.

See `NZSHM22_AbstractInversionRunner.setEnableInversionStateLogging()` for how to use this logging and for how to set up the inversion runner to log repeatably at each iteration.