### PR TITLE
Draft: Feature/346 build info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ bin/**
 .ParameterRunner.config
 src/main/java/nz/cri/gns/NZSHM22/opensha/util/OakleyRunner.java
 derby.log
+nzshm-build.date
+nzshm-build.gitbranch
+nzshm-build.githash
+nzshm-build.gitremoteurl

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
 task fatJar(type: Jar, dependsOn: ':opensha:fatJar') {
 
     doFirst {->
-        writeBuildFiles("nzshm-build")
+        writeBuildFiles("/nzshm-build")
     }
     doLast {
         delete new File(projectDir, "nzshm-build.githash")
@@ -92,6 +92,12 @@ task fatJar(type: Jar, dependsOn: ':opensha:fatJar') {
         configurations.apiResolvable.collect { it.isDirectory() ? it : zipTree(it).matching {
             exclude { it.path.contains('META-INF') }
         }}
+    }
+    from(project.projectDir) {
+        include 'nzshm-build.githash'
+        include 'nzshm-build.gitbranch'
+        include 'nzshm-build.gitremoteurl'
+        include 'nzshm-build.date'
     }
 
     // include compiled source from this project

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,12 @@ task fatJar(type: Jar, dependsOn: ':opensha:fatJar') {
     doFirst {->
         writeBuildFiles("nzshm-build")
     }
+    doLast {
+        delete new File(projectDir, "nzshm-build.githash")
+        delete new File(projectDir, "nzshm-build.gitbranch")
+        delete new File(projectDir, "nzshm-build.gitremoteurl")
+        delete new File(projectDir, "nzshm-build.date")
+    }
 
     baseName = project.name + '-all'
     from {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 compileJava.options.encoding = "UTF-8"
 
+apply from: '../opensha/build-git.gradle'
+
 dependencies {
     /* no remote repo */
     implementation files('python/share/py4j/py4j0.10.9.1.jar', //Py4j jar installed locally  via `pip install py4j`
@@ -74,6 +76,11 @@ dependencies {
 }
 
 task fatJar(type: Jar, dependsOn: ':opensha:fatJar') {
+
+    doFirst {->
+        writeBuildFiles("nzshm-build")
+    }
+
     baseName = project.name + '-all'
     from {
         configurations.apiResolvable.collect { it.isDirectory() ? it : zipTree(it).matching {

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
@@ -15,6 +15,7 @@ import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
 import org.opensha.commons.data.function.HistogramFunction;
 import org.opensha.commons.geo.json.FeatureProperties;
 import org.opensha.commons.util.DataUtils.MinMaxAveTracker;
+import org.opensha.commons.util.GitVersion;
 import org.opensha.commons.util.io.archive.ArchiveInput;
 import org.opensha.commons.util.modules.helpers.CSV_BackedModule;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
@@ -23,6 +24,7 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionInputGener
 import org.opensha.sha.earthquake.faultSysSolution.inversion.Inversions;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ReweightEvenFitSimulatedAnnealing;
+import org.opensha.sha.earthquake.faultSysSolution.modules.BuildInfoModule;
 import org.opensha.sha.earthquake.faultSysSolution.modules.ClusterRuptures;
 import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfitStats;
 import org.opensha.sha.earthquake.faultSysSolution.reports.plots.RupHistogramPlots.HistScalar;
@@ -872,8 +874,12 @@ public abstract class NZSHM22_AbstractInversionRunner {
 		}
 		printRuptureExclusionStats(zeroRates, "rates_");
 
+		BuildInfoModule buildInfo = BuildInfoModule.fromGitVersion(new GitVersion(new File("../opensha").getAbsoluteFile(), "/build"));
+		buildInfo.addExtra(new GitVersion(new File("").getAbsoluteFile(), "/nzshm-build"));
+
 		solution = new FaultSystemSolution(rupSet, solution_adjusted);
 		solution.addModule(progress.getProgress());
+		solution.addModule(buildInfo);
 		if (tsa instanceof ReweightEvenFitSimulatedAnnealing) {
 			solution.addModule(((ReweightEvenFitSimulatedAnnealing) tsa).getMisfitProgress());
 		}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
@@ -874,8 +874,8 @@ public abstract class NZSHM22_AbstractInversionRunner {
 		}
 		printRuptureExclusionStats(zeroRates, "rates_");
 
-		BuildInfoModule buildInfo = BuildInfoModule.fromGitVersion(new GitVersion(new File("../opensha").getAbsoluteFile(), "/build"));
-		buildInfo.addExtra(new GitVersion(new File("").getAbsoluteFile(), "/nzshm-build"));
+		BuildInfoModule buildInfo = BuildInfoModule.fromGitVersion(new GitVersion(new File("../opensha"), "/build"));
+		buildInfo.addExtra(new GitVersion(new File(""), "/nzshm-build"));
 
 		solution = new FaultSystemSolution(rupSet, solution_adjusted);
 		solution.addModule(progress.getProgress());

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.*;
 
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.*;
+import nz.cri.gns.NZSHM22.opensha.ruptures.NZSHM22_AbstractRuptureSetBuilder;
 import nz.cri.gns.NZSHM22.opensha.util.SimpleGeoJsonBuilder;
 import org.apache.commons.math3.util.Precision;
 import org.dom4j.DocumentException;
@@ -874,12 +875,9 @@ public abstract class NZSHM22_AbstractInversionRunner {
 		}
 		printRuptureExclusionStats(zeroRates, "rates_");
 
-		BuildInfoModule buildInfo = BuildInfoModule.fromGitVersion(new GitVersion(new File("../opensha"), "/build"));
-		buildInfo.addExtra(new GitVersion(new File(""), "/nzshm-build"));
-
 		solution = new FaultSystemSolution(rupSet, solution_adjusted);
 		solution.addModule(progress.getProgress());
-		solution.addModule(buildInfo);
+		solution.addModule(NZSHM22_AbstractRuptureSetBuilder.createBuildInfo());
 		if (tsa instanceof ReweightEvenFitSimulatedAnnealing) {
 			solution.addModule(((ReweightEvenFitSimulatedAnnealing) tsa).getMisfitProgress());
 		}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_AbstractRuptureSetBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_AbstractRuptureSetBuilder.java
@@ -7,10 +7,12 @@ import nz.cri.gns.NZSHM22.opensha.ruptures.downDip.DownDipSubSectBuilder;
 import nz.cri.gns.NZSHM22.opensha.faults.FaultSectionList;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
+import org.opensha.commons.util.GitVersion;
 import org.opensha.commons.util.XMLUtils;
 import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.RupSetScalingRelationship;
+import org.opensha.sha.earthquake.faultSysSolution.modules.BuildInfoModule;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRuptureBuilder;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
@@ -152,6 +154,12 @@ public abstract class NZSHM22_AbstractRuptureSetBuilder {
             description += filter.toDescription();
         }
         return description;
+    }
+
+    public static BuildInfoModule createBuildInfo() throws IOException {
+        BuildInfoModule buildInfo = BuildInfoModule.fromGitVersion(new GitVersion(new File("../opensha"), "/build"));
+        buildInfo.addExtra(new GitVersion(new File(""), "/nzshm-build"));
+        return buildInfo;
     }
     
     public abstract FaultSystemRupSet buildRuptureSet() throws DocumentException, IOException ;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_CoulombRuptureSetBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_CoulombRuptureSetBuilder.java
@@ -9,7 +9,9 @@ import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_FaultModels;
 import nz.cri.gns.NZSHM22.opensha.faults.FaultSectionList;
 import nz.cri.gns.NZSHM22.opensha.util.ParameterRunner;
 import org.dom4j.DocumentException;
+import org.opensha.commons.util.GitVersion;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.modules.BuildInfoModule;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRuptureBuilder;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
@@ -567,12 +569,15 @@ public class NZSHM22_CoulombRuptureSetBuilder extends NZSHM22_AbstractRuptureSet
         System.out.println("Built " + countDF.format(ruptures.size()) + " ruptures in " + timeDF.format(secs)
                 + " secs = " + timeDF.format(mins) + " mins. Total rate: " + rupRate(ruptures.size(), millis));
 
+        BuildInfoModule buildInfo = BuildInfoModule.fromGitVersion(new GitVersion(new File("../opensha"), "/build"));
+        buildInfo.addExtra(new GitVersion(new File(""), "/nzshm-build"));
 
         FaultSystemRupSet rupSet =
                 FaultSystemRupSet.builderForClusterRups(subSections, ruptures)
                         .forScalingRelationship(getScalingRelationship())
                         .slipAlongRupture(getSlipAlongRuptureModel())
                         .addModule(getLogicTreeBranch(FaultRegime.CRUSTAL))
+                        .addModule(buildInfo)
                         .build();
 
         return rupSet;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_CoulombRuptureSetBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_CoulombRuptureSetBuilder.java
@@ -569,15 +569,12 @@ public class NZSHM22_CoulombRuptureSetBuilder extends NZSHM22_AbstractRuptureSet
         System.out.println("Built " + countDF.format(ruptures.size()) + " ruptures in " + timeDF.format(secs)
                 + " secs = " + timeDF.format(mins) + " mins. Total rate: " + rupRate(ruptures.size(), millis));
 
-        BuildInfoModule buildInfo = BuildInfoModule.fromGitVersion(new GitVersion(new File("../opensha"), "/build"));
-        buildInfo.addExtra(new GitVersion(new File(""), "/nzshm-build"));
-
         FaultSystemRupSet rupSet =
                 FaultSystemRupSet.builderForClusterRups(subSections, ruptures)
                         .forScalingRelationship(getScalingRelationship())
                         .slipAlongRupture(getSlipAlongRuptureModel())
                         .addModule(getLogicTreeBranch(FaultRegime.CRUSTAL))
-                        .addModule(buildInfo)
+                        .addModule(createBuildInfo())
                         .build();
 
         return rupSet;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_SubductionRuptureSetBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_SubductionRuptureSetBuilder.java
@@ -280,6 +280,7 @@ public class NZSHM22_SubductionRuptureSetBuilder extends NZSHM22_AbstractRupture
                         .addModule(getPlausibilityConfig().getDistAzCalc())
                         .addModule(getPlausibilityConfig())
                         .addModule(getLogicTreeBranch(FaultRegime.SUBDUCTION))
+                        .addModule(createBuildInfo())
                         .build();
 
         return rupSet;


### PR DESCRIPTION
closes #346 

With https://github.com/opensha/opensha/pull/138 merged, this adds better build info to our rupture sets and inversion solutions. Here is an example for an inversion run:

The rupture set build info has human readable dates added:

```json
{
  "buildTime": 1648065102244,
  "buildTimeHuman": "Thu Mar 24 08:51:42 NZDT 2022",
  "gitHash": "5f057f4a589a82a1d71e09c376c560737a430928",
  "branch": "tmp/cdc-misfits-stats3",
  "openshaVersion": "1.5.2",
  "creationTime": 1648091767162,
  "creationTimeHuman": "Thu Mar 24 16:16:07 NZDT 2022"
}
```

Note that this is an old build info with data for only `OpenSHA` and nothing for `nzshm-opensha`. New rupture sets will also have `nzshm-opensha` build info data.

The solution has the following build info:

```json
{
  "buildTime": 1734321616939,
  "buildTimeHuman": "Mon Dec 16 17:00:16 NZDT 2024",
  "gitHash": "4fd45e6a2456f24b2f98bf0996523c2d348cb7c8",
  "branch": "upstream-master",
  "remoteUrl": "https://github.com/GNS-Science/opensha.git",
  "openshaVersion": "1.5.2",
  "creationTime": 1734387407297,
  "creationTimeHuman": "Tue Dec 17 11:16:47 NZDT 2024",
  "extra": [
    {
      "gitHash": "34ee3a3e70d8876348087063bd16de6079337aac",
      "buildTime": "Tue Dec 17 11:16:00 NZDT 2024",
      "remoteUrl": "https://github.com/GNS-Science/nzshm-opensha.git",
      "branch": "feature/346-build-info"
    }
  ]
}
```

The `extra` section is `nzshm-opensha` build info. Note that the build time for OpenSHA is different from the build time for nzshm-opensha. This is because I built a fatJar last evening, and the OpenSHA jar for it was re-used in a fatJar build this morning.