### PR TITLE
[370] Post build failures to Slack

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
     - name: Clone opensha fork
-      if:  github.event_name != 'schedule'
+      if: github.event_name != 'schedule'
       uses: actions/checkout@v2
       with:
         repository: GNS-Science/opensha
@@ -29,7 +29,7 @@ jobs:
         path: opensha
 
     - name: Clone opensha
-      if:  github.event_name != 'schedule'
+      if: github.event_name != 'schedule'
       uses: actions/checkout@v2
       with:
         repository: opensha/opensha

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
     - name: Clone opensha fork
-      if: github.event.schedule != '20 15 * * 0'
+      if:  github.event_name != 'schedule'
       uses: actions/checkout@v2
       with:
         repository: GNS-Science/opensha
@@ -29,7 +29,7 @@ jobs:
         path: opensha
 
     - name: Clone opensha
-      if: github.event.schedule == '20 15 * * 0'
+      if:  github.event_name != 'schedule'
       uses: actions/checkout@v2
       with:
         repository: opensha/opensha
@@ -103,3 +103,15 @@ jobs:
         AWS_REGION: 'ap-southeast-2'
         SOURCE_DIR: main/build/libs/
         destination_dir: ''
+
+    #----------------------------------------------
+    #       Post error msg to Slack for failed scheduled builds
+    #----------------------------------------------
+    - name: Post a Slack message if build failed
+      uses: slackapi/slack-github-action@v2.0.0
+      if: failure() && github.event_name == 'schedule'
+      with:
+        webhook: ${{ secrets.SCHEDULED_GITHUB_SLACK_WEBHOOK }}
+        webhook-type: incoming-webhook
+        payload: |
+          text: "⚠️*${{ github.event.repository.name }}: ${{ job.status }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"

--- a/.github/workflows/smokeTest.yml
+++ b/.github/workflows/smokeTest.yml
@@ -52,7 +52,7 @@ jobs:
       #----------------------------------------------
       - name: Post a Slack message if build failed
         uses: slackapi/slack-github-action@v2.0.0
-        if: failure() || true # && github.event_name == 'schedule'
+        if: failure() && github.event_name == 'schedule'
         with:
           webhook: ${{ secrets.SCHEDULED_GITHUB_SLACK_WEBHOOK }}
           webhook-type: incoming-webhook

--- a/.github/workflows/smokeTest.yml
+++ b/.github/workflows/smokeTest.yml
@@ -57,4 +57,4 @@ jobs:
           webhook: ${{ secrets.SCHEDULED_GITHUB_SLACK_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
-            text: "⚠️*scheduled smoke tests: ${{ job.status }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+            text: "⚠️*${{ github.event.repository.name }}: ${{ job.status }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"

--- a/.github/workflows/smokeTest.yml
+++ b/.github/workflows/smokeTest.yml
@@ -52,7 +52,7 @@ jobs:
       #----------------------------------------------
       - name: Post a Slack message if build failed
         uses: slackapi/slack-github-action@v2.0.0
-        if: failure() # && github.event_name == 'schedule'
+      #  if: failure() # && github.event_name == 'schedule'
         with:
           webhook: ${{ secrets.SCHEDULED_GITHUB_SLACK_WEBHOOK }}
           webhook-type: incoming-webhook

--- a/.github/workflows/smokeTest.yml
+++ b/.github/workflows/smokeTest.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: GNS-Science/opensha
-          ref: fix/rup-normalization
+          ref: fix/rup-normalization-2024
           path: opensha
 
       - name: Clone opensha

--- a/.github/workflows/smokeTest.yml
+++ b/.github/workflows/smokeTest.yml
@@ -46,3 +46,15 @@ jobs:
           cd main
           chmod +x gradlew
           ./gradlew smokeTest
+
+      #----------------------------------------------
+      #       Post error msg to Slack for failed scheduled builds
+      #----------------------------------------------
+      - name: Post a Slack message if build failed
+        uses: slackapi/slack-github-action@v2.0.0
+        if: failure() # && github.event_name == 'schedule'
+        with:
+          webhook: ${{ secrets.SCHEDULED_GITHUB_SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "⚠️*scheduled smoke tests: ${{ job.status }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.event.repository.name }}>"

--- a/.github/workflows/smokeTest.yml
+++ b/.github/workflows/smokeTest.yml
@@ -41,6 +41,12 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
+      - name: debug folder structure
+        run: |
+          pwd
+          ls -la
+          ls -la opensha
+
       - name: Build with Gradle
         run: |
           cd main
@@ -52,7 +58,7 @@ jobs:
       #----------------------------------------------
       - name: Post a Slack message if build failed
         uses: slackapi/slack-github-action@v2.0.0
-      #  if: failure() # && github.event_name == 'schedule'
+        if: failure() || success() # && github.event_name == 'schedule'
         with:
           webhook: ${{ secrets.SCHEDULED_GITHUB_SLACK_WEBHOOK }}
           webhook-type: incoming-webhook

--- a/.github/workflows/smokeTest.yml
+++ b/.github/workflows/smokeTest.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Clone opensha fork
-        if: github.event.schedule != '20 15 * * 0'
+        if: github.event_name != 'schedule'
         uses: actions/checkout@v2
         with:
           repository: GNS-Science/opensha
@@ -24,7 +24,7 @@ jobs:
           path: opensha
 
       - name: Clone opensha
-        if: github.event.schedule == '20 15 * * 0'
+        if: github.event_name == 'schedule'
         uses: actions/checkout@v2
         with:
           repository: opensha/opensha
@@ -41,12 +41,6 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
-      - name: debug folder structure
-        run: |
-          pwd
-          ls -la
-          ls -la opensha
-
       - name: Build with Gradle
         run: |
           cd main
@@ -58,9 +52,9 @@ jobs:
       #----------------------------------------------
       - name: Post a Slack message if build failed
         uses: slackapi/slack-github-action@v2.0.0
-        if: failure() || success() # && github.event_name == 'schedule'
+        if: failure() || true # && github.event_name == 'schedule'
         with:
           webhook: ${{ secrets.SCHEDULED_GITHUB_SLACK_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
-            text: "⚠️*scheduled smoke tests: ${{ job.status }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.event.repository.name }}>"
+            text: "⚠️*scheduled smoke tests: ${{ job.status }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_AbstractRuptureSetBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/NZSHM22_AbstractRuptureSetBuilder.java
@@ -167,6 +167,7 @@ public abstract class NZSHM22_AbstractRuptureSetBuilder {
 
     public NZSHM22_AbstractRuptureSetBuilder setFaultModel(NZSHM22_FaultModels faultModel) {
         Preconditions.checkState(this.downDipFile == null);
+        Preconditions.checkState((!faultModel.isCrustal()) || faultModel.getTvzDomain() != null);
         this.faultModel = faultModel;
         return this;
     }

--- a/src/smokeTest/java/nz/cri/gns/NZSHM22/SmokeTest.java
+++ b/src/smokeTest/java/nz/cri/gns/NZSHM22/SmokeTest.java
@@ -67,7 +67,6 @@ public class SmokeTest {
         assertEquals(133, rupSet.getSlipRateForAllSections().length);
         assertEquals(133, rupSet.getSlipRateStdDevForAllSections().length);
 
-
         // sanity check first rupture
         assertEquals("Acton", rupSet.getFaultSectionData(0).getParentSectionName());
         assertEquals(2.0e-4, rupSet.getSlipRateForSection(0), 0.0000000001);

--- a/src/smokeTest/java/nz/cri/gns/NZSHM22/SmokeTest.java
+++ b/src/smokeTest/java/nz/cri/gns/NZSHM22/SmokeTest.java
@@ -29,7 +29,6 @@ public class SmokeTest {
     @BeforeClass
     public static void setup() throws IOException {
         tempDir = Files.createTempDirectory("opensha").toFile();
-        System.out.println("tempdir" + tempDir.exists());
         System.out.println("smoke tests directory: " + tempDir);
     }
 
@@ -68,10 +67,6 @@ public class SmokeTest {
         assertEquals(133, rupSet.getSlipRateForAllSections().length);
         assertEquals(133, rupSet.getSlipRateStdDevForAllSections().length);
 
-
-        System.out.println( rupSet.getSlipRateForSection(0));
-        System.out.println( rupSet.getSlipRateStdDevForSection(0));
-        System.out.println(rupSet.getMagForRup(0));
 
         // sanity check first rupture
         assertEquals("Acton", rupSet.getFaultSectionData(0).getParentSectionName());
@@ -242,9 +237,6 @@ public class SmokeTest {
     public void testRupSetReportPageGen(File rupSetFile) throws IOException {
         File outputDir = new File(rupSetFile.getParentFile(), "ruptureReport");
         outputDir.mkdir();
-
-        System.out.println(outputDir.exists());
-        System.out.println(rupSetFile.exists());
 
         NZSHM22_PythonGateway.getReportPageGen()
                 .setRuptureSet(rupSetFile.getAbsolutePath())

--- a/src/smokeTest/java/nz/cri/gns/NZSHM22/SmokeTest.java
+++ b/src/smokeTest/java/nz/cri/gns/NZSHM22/SmokeTest.java
@@ -46,7 +46,7 @@ public class SmokeTest {
         testCrustalInversionRunner(ruptureSetFile, solutionFile);
         testSolutionReportPageGen(solutionFile);
         testMFDPlotBuilder(mfdDir, solutionFile, true);
-        testHazard(solutionFile, "INCLUDE");
+        // testHazard(solutionFile, "INCLUDE");
     }
 
     @Test
@@ -60,19 +60,24 @@ public class SmokeTest {
         testRupSetReportPageGen(ruptureSetFile);
         testSubductionInversionRunner(ruptureSetFile, solutionFile);
         testSolutionReportPageGen(solutionFile);
-        testHazard(solutionFile, "EXCLUDE");
+        // testHazard(solutionFile, "EXCLUDE");
     }
 
     public void sanityCheckCoulombRuptureSet(FaultSystemRupSet rupSet) {
-        assertEquals(3064, rupSet.getNumRuptures());
-        assertEquals(145, rupSet.getSlipRateForAllSections().length);
-        assertEquals(145, rupSet.getSlipRateStdDevForAllSections().length);
+        assertEquals(2335, rupSet.getNumRuptures());
+        assertEquals(133, rupSet.getSlipRateForAllSections().length);
+        assertEquals(133, rupSet.getSlipRateStdDevForAllSections().length);
+
+
+        System.out.println( rupSet.getSlipRateForSection(0));
+        System.out.println( rupSet.getSlipRateStdDevForSection(0));
+        System.out.println(rupSet.getMagForRup(0));
 
         // sanity check first rupture
         assertEquals("Acton", rupSet.getFaultSectionData(0).getParentSectionName());
         assertEquals(2.0e-4, rupSet.getSlipRateForSection(0), 0.0000000001);
         assertEquals(1.5e-4, rupSet.getSlipRateStdDevForSection(0), 0.0000000001);
-        assertEquals(6.890572888121233, rupSet.getMagForRup(0), 0.0000000001);
+        assertEquals(7.134465576851742, rupSet.getMagForRup(0), 0.0000000001);
     }
 
     public void testCoulombRuptures(File ruptureSetFile) throws DocumentException, IOException {
@@ -91,7 +96,7 @@ public class SmokeTest {
                         .setMaxJumpDistance(15d)
                         .setAdaptiveSectFract(0.1f)
                         .setIdRangeFilter(0, 40)
-                        .setFaultModel(NZSHM22_FaultModels.CFM_0_9A_ALL_D90)
+                        .setFaultModel(NZSHM22_FaultModels.CFM_1_0_DOM_ALL)
                         .setScalingRelationship(scaling)
                         .setSlipAlongRuptureModel(SlipAlongRuptureModels.TAPERED)
                         .buildRuptureSet();

--- a/src/smokeTest/java/nz/cri/gns/NZSHM22/SmokeTest.java
+++ b/src/smokeTest/java/nz/cri/gns/NZSHM22/SmokeTest.java
@@ -29,22 +29,8 @@ public class SmokeTest {
     @BeforeClass
     public static void setup() throws IOException {
         tempDir = Files.createTempDirectory("opensha").toFile();
+        System.out.println("tempdir" + tempDir.exists());
         System.out.println("smoke tests directory: " + tempDir);
-    }
-
-    @Test
-    public void testAzimuthalCrustal() throws DocumentException, IOException {
-        File dir = new File(tempDir, "azimuthal");
-        dir.mkdir();
-        File ruptureSetFile = new File(dir, "rupSet.zip");
-        File solutionFile = new File(dir, "solution.zip");
-        File mfdDir = new File(dir, "MFDPlots");
-
-        testRupSetReportPageGen(ruptureSetFile);
-        testCrustalInversionRunner(ruptureSetFile, solutionFile);
-        testSolutionReportPageGen(solutionFile);
-        testMFDPlotBuilder(mfdDir, solutionFile, true);
-        testHazard(solutionFile, "INCLUDE");
     }
 
     @Test
@@ -251,6 +237,9 @@ public class SmokeTest {
     public void testRupSetReportPageGen(File rupSetFile) throws IOException {
         File outputDir = new File(rupSetFile.getParentFile(), "ruptureReport");
         outputDir.mkdir();
+
+        System.out.println(outputDir.exists());
+        System.out.println(rupSetFile.exists());
 
         NZSHM22_PythonGateway.getReportPageGen()
                 .setRuptureSet(rupSetFile.getAbsolutePath())


### PR DESCRIPTION
Closes #370

- Added Slack notifications to both workflows. They will be triggered if the build is scheduled and fails. This is so that we notice when the build fails.
- SmokeTest.java was outdated and tested functionality that was removed and a fault model that was deprecated.
- Hazard calculation is currently broken until https://github.com/GNS-Science/nzshm-opensha/issues/355 is fixed.