### PR TITLE
[377] Fix TVZ MFDs

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/griddedSeismicity/NZSHM22_GridSourceGenerator.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/griddedSeismicity/NZSHM22_GridSourceGenerator.java
@@ -8,6 +8,7 @@ import nz.cri.gns.NZSHM22.opensha.data.region.NewZealandRegions;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_LogicTreeBranch;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_Regions;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_SpatialSeisPDF;
+import nz.cri.gns.NZSHM22.opensha.inversion.NZSHM22_InversionFaultSystemRuptSet;
 import org.opensha.commons.geo.GriddedRegion;
 import org.opensha.commons.gui.plot.GraphWindow;
 import org.opensha.commons.util.DataUtils;
@@ -66,6 +67,9 @@ public class NZSHM22_GridSourceGenerator extends AbstractGridSourceProvider {
      *     be generated
      */
     public NZSHM22_GridSourceGenerator(FaultSystemSolution ifss) {
+
+        NZSHM22_InversionFaultSystemRuptSet.checkMFDConsistency(ifss.getRupSet());
+
         branch = ifss.getRupSet().getModule(NZSHM22_LogicTreeBranch.class);
         NZSHM22_SpatialSeisPDF spatialSeisPDF = branch.getValue(NZSHM22_SpatialSeisPDF.class);
 

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionConfiguration.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionConfiguration.java
@@ -3,10 +3,7 @@ package nz.cri.gns.NZSHM22.opensha.inversion;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.IntPredicate;
-import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_LogicTreeBranch;
-import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_Regions;
-import org.opensha.commons.geo.GriddedRegion;
+import nz.cri.gns.NZSHM22.opensha.data.region.NewZealandRegions;
 import org.opensha.sha.magdist.IncrementalMagFreqDist;
 import scratch.UCERF3.enumTreeBranches.InversionModels;
 
@@ -20,31 +17,21 @@ import scratch.UCERF3.enumTreeBranches.InversionModels;
  */
 public class NZSHM22_CrustalInversionConfiguration extends AbstractInversionConfiguration {
 
-    protected static final boolean D = true; // for debugging
     private double paleoRateConstraintWt;
     private double mfdSmoothnessConstraintWtForPaleoParents;
 
     /** */
     public NZSHM22_CrustalInversionConfiguration() {}
 
-    public static final double DEFAULT_MFD_EQUALITY_WT = 10;
-    public static final double DEFAULT_MFD_INEQUALITY_WT = 1000;
-
     public static void setRegionalData(
             NZSHM22_InversionFaultSystemRuptSet rupSet, double mMin_Sans, double mMin_TVZ) {
 
-        NZSHM22_LogicTreeBranch branch = rupSet.getModule(NZSHM22_LogicTreeBranch.class);
-        NZSHM22_Regions regions = branch.getValue(NZSHM22_Regions.class);
-
-        GriddedRegion tvzRegion = regions.getTvzRegion();
-        GriddedRegion sansTvzRegion = regions.getSansTvzRegion();
-
-        TvzDomainSections tvzSections = rupSet.getModule(TvzDomainSections.class);
-        IntPredicate tvzFilter = tvzSections::isInRegion;
-
-        RegionalRupSetData tvz = new RegionalRupSetData(rupSet, tvzRegion, tvzFilter, mMin_TVZ);
+        // TVZ is hard-coded to always be empty, and sansTVZ is hardcoded to always be all of NZ
+        RegionalRupSetData tvz =
+                new RegionalRupSetData(
+                        rupSet, new NewZealandRegions.NZ_EMPTY_GRIDDED(), id -> false, mMin_TVZ);
         RegionalRupSetData sansTvz =
-                new RegionalRupSetData(rupSet, sansTvzRegion, tvzFilter.negate(), mMin_Sans);
+                new RegionalRupSetData(rupSet, NewZealandRegions.NZ, id -> true, mMin_Sans);
 
         rupSet.setRegionalData(tvz, sansTvz);
     }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunner.java
@@ -36,7 +36,7 @@ public class NZSHM22_CrustalInversionRunner extends NZSHM22_AbstractInversionRun
     private double sansSlipRateFactor = -1;
     private double tvzSlipRateFactor = -1;
 
-    private boolean enableTvzMFDs = true;
+    private boolean enableTvzMFDs = false;
     private boolean enableMinMaxSampler = false;
 
     private NZSHM22_PolygonisedDistributedModelBuilder polygoniser = null;
@@ -73,6 +73,9 @@ public class NZSHM22_CrustalInversionRunner extends NZSHM22_AbstractInversionRun
      * @return
      */
     public NZSHM22_CrustalInversionRunner setEnableTvzMFDs(boolean enableTvz) {
+        if (enableTvz) {
+            throw new RuntimeException("This feature is not currently supported.");
+        }
         this.enableTvzMFDs = enableTvz;
         return this;
     }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionTargetMFDs.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionTargetMFDs.java
@@ -118,7 +118,7 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
         public GriddedRegion region;
         public String suffix;
         public RegionalRupSetData regionalRupSet;
-        public boolean ignore = false;
+        public boolean isEmpty = false;
 
         public double totalRateM5;
         public double bValue;
@@ -152,17 +152,14 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
             this.maxMag = maxMag;
             this.uncertaintyPower = uncertaintyPower;
             this.uncertaintyScalar = uncertaintyScalar;
-            if (region.getName().contains("SANS TVZ")
-                    || region.getName().contains("NZ_RECTANGLE")) {
-                suffix = "SansTVZ";
-            } else if (region.getName().contains("TVZ")) {
+            if (!region.getName().contains("SANS") && region.getName().contains("TVZ")) {
                 suffix = "TVZ";
             } else {
-                suffix = "";
+                suffix = "SansTVZ";
             }
             this.regionalRupSet = regionalRupSet;
             if (regionalRupSet.isEmpty()) {
-                ignore = true;
+                isEmpty = true;
             } else {
                 init();
             }
@@ -183,15 +180,15 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
             out.name("minMag");
             out.value(minMag);
 
-            // hint for writing a readr: this value is not present in older versions
+            // hint for writing a reader: this value is not present in older versions
             out.name("maxMag");
             out.value(maxMag);
 
-            // hint for writing a readr: this value is not present in older versions
+            // hint for writing a reader: this value is not present in older versions
             out.name("uncertaintyPower");
             out.value(uncertaintyPower);
 
-            // hint for writing a readr: this value is not present in older versions
+            // hint for writing a reader: this value is not present in older versions
             out.name("uncertaintyScalar");
             out.value(uncertaintyScalar);
 
@@ -384,13 +381,13 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
         // Build the MFD Constraints for regions
         mfdConstraints = new ArrayList<>();
         mfdConstraints.add(sansTvz.targetOnFaultSupraSeisMFDs);
-        if (!tvz.ignore) {
+        if (!tvz.isEmpty) {
             mfdConstraints.add(tvz.targetOnFaultSupraSeisMFDs);
         }
 
         mfdUncertaintyConstraints = new ArrayList<>();
         mfdUncertaintyConstraints.add(sansTvz.uncertaintyMFD);
-        if (!tvz.ignore) {
+        if (!tvz.isEmpty) {
             mfdUncertaintyConstraints.add(tvz.uncertaintyMFD);
         }
 
@@ -404,7 +401,7 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
 
         SummedMagFreqDist tempTargetGR = new SummedMagFreqDist(NZ_MIN_MAG, NZ_NUM_BINS, DELTA_MAG);
         tempTargetGR.addIncrementalMagFreqDist(sansTvz.totalTargetGR);
-        if (!tvz.ignore) {
+        if (!tvz.isEmpty) {
             tempTargetGR.addIncrementalMagFreqDist(tvz.totalTargetGR);
         }
 
@@ -416,7 +413,7 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
         SummedMagFreqDist tempTrulyOffFaultMFD =
                 new SummedMagFreqDist(NZ_MIN_MAG, NZ_NUM_BINS, DELTA_MAG);
         tempTrulyOffFaultMFD.addIncrementalMagFreqDist(sansTvz.trulyOffFaultMFD);
-        if (!tvz.ignore) {
+        if (!tvz.isEmpty) {
             tempTrulyOffFaultMFD.addIncrementalMagFreqDist(tvz.trulyOffFaultMFD);
         }
 
@@ -429,21 +426,21 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
         // CHECK: New MFD addition approach....
         totalSubSeismoOnFaultMFD = new SummedMagFreqDist(NZ_MIN_MAG, NZ_NUM_BINS, DELTA_MAG);
         totalSubSeismoOnFaultMFD.addIncrementalMagFreqDist(sansTvz.totalSubSeismoOnFaultMFD);
-        if (!tvz.ignore) {
+        if (!tvz.isEmpty) {
             totalSubSeismoOnFaultMFD.addIncrementalMagFreqDist(tvz.totalSubSeismoOnFaultMFD);
         }
 
         // TODO is this correct? It's just a guess by Oakley (and now Chris)
         ArrayList<GutenbergRichterMagFreqDist> subSeismoOnFaultMFD_List = new ArrayList<>();
         subSeismoOnFaultMFD_List.addAll(sansTvz.subSeismoOnFaultMFD_List);
-        if (!tvz.ignore) {
+        if (!tvz.isEmpty) {
             subSeismoOnFaultMFD_List.addAll(tvz.subSeismoOnFaultMFD_List);
         }
         subSeismoOnFaultMFDs = new SubSeismoOnFaultMFDs(subSeismoOnFaultMFD_List);
 
         targetOnFaultSupraSeisMFD = new SummedMagFreqDist(NZ_MIN_MAG, NZ_NUM_BINS, DELTA_MAG);
         targetOnFaultSupraSeisMFD.addIncrementalMagFreqDist(sansTvz.targetOnFaultSupraSeisMFDs);
-        if (!tvz.ignore) {
+        if (!tvz.isEmpty) {
             targetOnFaultSupraSeisMFD.addIncrementalMagFreqDist(tvz.targetOnFaultSupraSeisMFDs);
         }
 
@@ -456,7 +453,7 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
         this.reportingMFDConstraintComponents = new ArrayList<>();
         this.reportingMFDConstraintComponents.add(trulyOffFaultMFD);
         this.reportingMFDConstraintComponents.add(sansTvz.targetOnFaultSupraSeisMFDs);
-        if (!tvz.ignore) {
+        if (!tvz.isEmpty) {
             this.reportingMFDConstraintComponents.add(tvz.targetOnFaultSupraSeisMFDs);
         }
         this.reportingMFDConstraintComponents.add(totalSubSeismoOnFaultMFD);
@@ -467,7 +464,7 @@ public class NZSHM22_CrustalInversionTargetMFDs extends U3InversionTargetMFDs {
         this.reportingMFDConstraintComponentsV2.add(trulyOffFaultMFD);
         this.reportingMFDConstraintComponentsV2.add(targetOnFaultSupraSeisMFD);
         this.reportingMFDConstraintComponentsV2.add(totalSubSeismoOnFaultMFD);
-        if (!tvz.ignore) {
+        if (!tvz.isEmpty) {
             this.reportingMFDConstraintComponentsV2.add(tvz.totalTargetGR);
             this.reportingMFDConstraintComponentsV2.add(sansTvz.totalTargetGR);
             this.reportingMFDConstraintComponentsV2.add(tvz.trulyOffFaultMFD);

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionFaultSystemRuptSet.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionFaultSystemRuptSet.java
@@ -304,4 +304,17 @@ public class NZSHM22_InversionFaultSystemRuptSet extends InversionFaultSystemRup
     public double getUpperMagForSubseismoRuptures(int sectIndex) {
         throw new RuntimeException("Not supported, don't use this!");
     }
+
+    /**
+     * Asserts that all fault sections have an MFD associated with them. This is to weed out
+     * solutions generated with code affected by #377 where sections in the TVZ were excluded from
+     * MFD generation.
+     */
+    public static void checkMFDConsistency(FaultSystemRupSet rupSet) {
+        int mfdSize = rupSet.getModule(InversionTargetMFDs.class).getOnFaultSubSeisMFDs().size();
+        if (mfdSize != rupSet.getNumSections()) {
+            throw new RuntimeException(
+                    "This solution was created with a faulty nzshm-opensha version. See issue #377.");
+        }
+    }
 }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/reports/NZSHM22_MFDPlot.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/reports/NZSHM22_MFDPlot.java
@@ -47,7 +47,7 @@ public class NZSHM22_MFDPlot extends AbstractRupSetPlot {
                 new SummedMagFreqDist(NZ_MIN_MAG, NZ_NUM_BINS, DELTA_MAG);
         targetOnFaultSupraSeisMFDs.addIncrementalMagFreqDist(
                 targetMFDs.getSansTvz().targetOnFaultSupraSeisMFDs);
-        if (!targetMFDs.getTvz().ignore) {
+        if (!targetMFDs.getTvz().isEmpty) {
             targetOnFaultSupraSeisMFDs.addIncrementalMagFreqDist(
                     targetMFDs.getTvz().targetOnFaultSupraSeisMFDs);
         }
@@ -78,7 +78,7 @@ public class NZSHM22_MFDPlot extends AbstractRupSetPlot {
                 "Target Supra-Seis");
         plots.add(sansPlot);
 
-        if (!targetMFDs.getTvz().ignore) {
+        if (!targetMFDs.getTvz().isEmpty) {
             MFD_Plot tvzPlot = new MFD_Plot("NZ TVZ Target MFDs", null);
             tvzPlot.addComp(
                     targetMFDs.getTvz().totalTargetGR, Color.GREEN.darker(), "Total Target GR");

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/util/MFDPlotBuilder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/util/MFDPlotBuilder.java
@@ -46,7 +46,7 @@ public class MFDPlotBuilder {
     }
 
     public void plot() throws IOException {
-        HashMap<String, Set<Integer>> parentSections = new HashMap<>();
+        HashMap<String, Set<Integer>> parentSections = null;
         if (faultModel == null) {
             NZSHM22_LogicTreeBranch branch =
                     solution.getRupSet().getModule(NZSHM22_LogicTreeBranch.class);
@@ -55,13 +55,16 @@ public class MFDPlotBuilder {
             }
         }
         if (faultModel != null) {
+            parentSections = new HashMap<>();
             Map<String, List<Integer>> namedFaultsMap = faultModel.getNamedFaultsMapAlt();
             if (namedFaultsMap != null) {
                 for (String name : namedFaultsMap.keySet()) {
                     parentSections.put(name, Sets.newHashSet(namedFaultsMap.get(name)));
                 }
             }
-        } else {
+        }
+        if (parentSections == null) {
+            parentSections = new HashMap<>();
             for (FaultSection sect : solution.getRupSet().getFaultSectionDataList()) {
                 if (!parentSections.containsKey(sect.getParentSectionName())) {
                     parentSections.put(

--- a/src/main/java/nz/cri/gns/NZSHM22/util/MFDPlot.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/util/MFDPlot.java
@@ -1,7 +1,6 @@
 package nz.cri.gns.NZSHM22.util;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
@@ -14,7 +13,6 @@ import org.opensha.commons.gui.plot.HeadlessGraphPanel;
 import org.opensha.commons.gui.plot.PlotCurveCharacterstics;
 import org.opensha.commons.gui.plot.PlotLineType;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
-import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.magdist.IncrementalMagFreqDist;
 import org.opensha.sha.magdist.SummedMagFreqDist;
 import scratch.UCERF3.analysis.CompoundFSSPlots;
@@ -42,17 +40,6 @@ public class MFDPlot {
         if (!nuclIncrSubDir.exists()) nuclIncrSubDir.mkdir();
         File nuclCmlSubDir = new File(dir, "nucleation_cumulative");
         if (!nuclCmlSubDir.exists()) nuclCmlSubDir.mkdir();
-
-        if (parents == null) {
-            parents = new HashMap<>();
-            for (FaultSection sect : sol.getRupSet().getFaultSectionDataList()) {
-                if (!parents.containsKey(sect.getParentSectionName())) {
-                    parents.put(
-                            sect.getParentSectionName(),
-                            Sets.newHashSet(sect.getParentSectionId()));
-                }
-            }
-        }
 
         // MFD extents
         double minMag = 5.05;

--- a/src/main/java/nz/cri/gns/NZSHM22/util/MFDPlotCalc.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/util/MFDPlotCalc.java
@@ -4,6 +4,7 @@ import java.awt.geom.Point2D;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import nz.cri.gns.NZSHM22.opensha.inversion.NZSHM22_InversionFaultSystemRuptSet;
 import org.opensha.commons.data.function.DiscretizedFunc;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
@@ -22,6 +23,7 @@ public class MFDPlotCalc {
             double maxMag,
             int numMag) {
         FaultSystemRupSet rupSet = solution.getRupSet();
+
         SummedMagFreqDist mfd = new SummedMagFreqDist(minMag, maxMag, numMag);
         for (int sectIndex = 0; sectIndex < rupSet.getNumSections(); sectIndex++) {
             if (parentSectionIDs.contains(
@@ -98,6 +100,8 @@ public class MFDPlotCalc {
 
     public static SummedMagFreqDist getFinalSubSeismoOnFaultMFDForSects(
             FaultSystemSolution solution, Set<Integer> parentSectionIDs) {
+
+        NZSHM22_InversionFaultSystemRuptSet.checkMFDConsistency(solution.getRupSet());
 
         SummedMagFreqDist mfd =
                 new SummedMagFreqDist(

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionConfigurationTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionConfigurationTest.java
@@ -5,12 +5,9 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_FaultModels;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_LogicTreeBranch;
 import org.dom4j.DocumentException;
-import org.junit.Test;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
 
@@ -30,28 +27,31 @@ public class NZSHM22_CrustalInversionConfigurationTest {
         return NZSHM22_InversionFaultSystemRuptSet.fromExistingCrustalSet(rupSet, branch);
     }
 
-    @Test
-    public void testRegions() throws IOException, DocumentException {
-        NZSHM22_InversionFaultSystemRuptSet rupSet = loadRupSet();
-        assertEquals(712, rupSet.getNumSections());
-
-        NZSHM22_CrustalInversionConfiguration.setRegionalData(rupSet, 5, 7);
-        RegionalRupSetData tvzData = rupSet.getTvzRegionalData();
-        RegionalRupSetData sansTvzData = rupSet.getSansTvzRegionalData();
-
-        // Assert that the sections are split between the regions with no overlap or omissions.
-        assertEquals(200, tvzData.getFaultSectionDataList().size());
-        assertEquals(512, sansTvzData.getFaultSectionDataList().size());
-        assertEquals(
-                List.of(true, true, true),
-                Stream.of(5, 6, 7).map(tvzData::isInRegion).collect(Collectors.toList()));
-        assertEquals(
-                List.of(true, true, true, true, true),
-                Stream.of(0, 1, 2, 3, 4).map(sansTvzData::isInRegion).collect(Collectors.toList()));
-
-        // sansTVZ min mag
-        assertEquals(5.0, rupSet.getFinalMinMagForSection(0), 0.00000001);
-        // TVZ min mag
-        assertEquals(7.0, rupSet.getFinalMinMagForSection(5), 0.00000001);
-    }
+    //    Regions are disabled at the moment
+    //    @Test
+    //    public void testRegions() throws IOException, DocumentException {
+    //        NZSHM22_InversionFaultSystemRuptSet rupSet = loadRupSet();
+    //        assertEquals(712, rupSet.getNumSections());
+    //
+    //        NZSHM22_CrustalInversionConfiguration.setRegionalData(rupSet, 5, 7);
+    //        RegionalRupSetData tvzData = rupSet.getTvzRegionalData();
+    //        RegionalRupSetData sansTvzData = rupSet.getSansTvzRegionalData();
+    //
+    //        // Assert that the sections are split between the regions with no overlap or
+    // omissions.
+    //        assertEquals(200, tvzData.getFaultSectionDataList().size());
+    //        assertEquals(512, sansTvzData.getFaultSectionDataList().size());
+    //        assertEquals(
+    //                List.of(true, true, true),
+    //                Stream.of(5, 6, 7).map(tvzData::isInRegion).collect(Collectors.toList()));
+    //        assertEquals(
+    //                List.of(true, true, true, true, true),
+    //                Stream.of(0, 1, 2, 3,
+    // 4).map(sansTvzData::isInRegion).collect(Collectors.toList()));
+    //
+    //        // sansTVZ min mag
+    //        assertEquals(5.0, rupSet.getFinalMinMagForSection(0), 0.00000001);
+    //        // TVZ min mag
+    //        assertEquals(7.0, rupSet.getFinalMinMagForSection(5), 0.00000001);
+    //    }
 }


### PR DESCRIPTION
closes #377

The short length of the `sub_seismo_on_fault_mfds.csv` file was due to sansTVZ accidentally being hard-coded to exclude TVZ sections since 0769505dafdd3ebe27d0443ba1423a95e8304cef (November 2024)

This means MFDs were constructed incorrectly, and solutions created using the faulty code should not be used.

We now detect this case in the instances it caused a problem (hazard and MFD plots) and throw a meaningful exception.

In the course of this investigation, I noticed that MFDs in a solution with regions are written in a different order from the one they are read in. Since it is unclear whether we will need the regions feature, I decided to hard-code one region to contain everything and the other region to contain nothing.

Once we know whether we want to use regions, we can either fix and re-enable this feature or remove it.