### PR TITLE
[372] paleo rates side loader

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/enumTreeBranches/NZSHM22_PaleoRates.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/enumTreeBranches/NZSHM22_PaleoRates.java
@@ -18,6 +18,8 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.Un
 import org.opensha.sha.faultSurface.FaultSection;
 
 public enum NZSHM22_PaleoRates implements LogicTreeNode {
+    CUSTOM("Paleo Rates are side-loaded from custom file", null),
+
     GEODETIC_SLIP_PRIOR_NO_TVZ(
             "Geodetic with Geologic prior timing, no TVZ",
             "NZNSHM_paleotimings_GEODETICGEOLOGICPRIOR_notvz.txt"),
@@ -81,12 +83,20 @@ public enum NZSHM22_PaleoRates implements LogicTreeNode {
 
     public List<UncertainDataConstraint.SectMappedUncertainDataConstraint> fetchConstraints(
             List<? extends FaultSection> faultSections) {
+        if (fileName == null) {
+            return new ArrayList<>();
+        }
+        return fetchConstraints(faultSections, getStream(fileName));
+    }
+
+    public static List<UncertainDataConstraint.SectMappedUncertainDataConstraint> fetchConstraints(
+            List<? extends FaultSection> faultSections, InputStream in) {
 
         List<UncertainDataConstraint.SectMappedUncertainDataConstraint> paleoRateConstraints =
                 new ArrayList<>();
         CSVFile<String> csv;
         try {
-            csv = CSVFile.readStream(getStream(fileName), false);
+            csv = CSVFile.readStream(in, false);
         } catch (IOException x) {
             x.printStackTrace();
             throw new RuntimeException(x);

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/enumTreeBranches/NZSHM22_PaleoRatesTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/enumTreeBranches/NZSHM22_PaleoRatesTest.java
@@ -22,7 +22,11 @@ public class NZSHM22_PaleoRatesTest {
             List<UncertainDataConstraint.SectMappedUncertainDataConstraint> constraints =
                     rates.fetchConstraints(sections);
 
-            assertFalse(constraints.isEmpty());
+            if (rates == NZSHM22_PaleoRates.CUSTOM) {
+                assertTrue(constraints.isEmpty());
+            } else {
+                assertFalse(constraints.isEmpty());
+            }
 
             for (UncertainDataConstraint.SectMappedUncertainDataConstraint constraint :
                     constraints) {

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunnerTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunnerTest.java
@@ -9,7 +9,10 @@ import nz.cri.gns.NZSHM22.opensha.util.ParameterRunner;
 import nz.cri.gns.NZSHM22.opensha.util.Parameters;
 import nz.cri.gns.NZSHM22.opensha.util.TestHelpers;
 import org.dom4j.DocumentException;
+import org.hamcrest.core.StringStartsWith;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.opensha.commons.util.io.archive.ArchiveOutput;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
@@ -74,5 +77,20 @@ public class NZSHM22_CrustalInversionRunnerTest {
             assertEquals(fromEnum.dataLocation, fromFile.dataLocation);
             assertEquals(fromEnum.sectionIndex, fromFile.sectionIndex);
         }
+    }
+
+    @Rule public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void testPaleoRatesDoubleUp() throws DocumentException, IOException {
+
+        NZSHM22_CrustalInversionRunner runner = makeRunner();
+        runner.setPaleoRateConstraints(0.4, 0.5, "PALEO_RI_GEOLOGIC_MAY24", "NZSHM22_C_42");
+        runner.setPaleoRatesFile(
+                "src/main/resources/paleoRates/NZNSHM_paleotimings_GEOLOGIC_24May.txt");
+
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage(new StringStartsWith("Paleo rate location double-up"));
+        runner.runInversion();
     }
 }

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunnerTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunnerTest.java
@@ -1,0 +1,78 @@
+package nz.cri.gns.NZSHM22.opensha.inversion;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.List;
+import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_FaultModels;
+import nz.cri.gns.NZSHM22.opensha.util.ParameterRunner;
+import nz.cri.gns.NZSHM22.opensha.util.Parameters;
+import nz.cri.gns.NZSHM22.opensha.util.TestHelpers;
+import org.dom4j.DocumentException;
+import org.junit.Test;
+import org.opensha.commons.util.io.archive.ArchiveOutput;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.UncertainDataConstraint;
+import org.opensha.sha.earthquake.faultSysSolution.modules.PaleoseismicConstraintData;
+import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
+
+public class NZSHM22_CrustalInversionRunnerTest {
+
+    // returns a runner that can quickly create a solution
+    public static NZSHM22_CrustalInversionRunner makeRunner()
+            throws DocumentException, IOException {
+        FaultSystemRupSet rupSet =
+                TestHelpers.makeRupSet(
+                        NZSHM22_FaultModels.CFM_1_0A_DOM_SANSTVZ,
+                        ScalingRelationships.SHAW_2009_MOD);
+        ArchiveOutput archiveOutput = new ArchiveOutput.InMemoryZipOutput(true);
+        rupSet.getArchive().write(archiveOutput);
+
+        ParameterRunner parameterRunner = new ParameterRunner(Parameters.NZSHM22.INVERSION_CRUSTAL);
+        NZSHM22_CrustalInversionRunner runner = new NZSHM22_CrustalInversionRunner();
+        parameterRunner.setUpCrustalInversionRunner(runner);
+        runner.setIterationCompletionCriteria(100)
+                .setSelectionIterations(1)
+                .setRepeatable(true)
+                .setInversionAveraging(false)
+                .setRuptureSetArchiveInput(archiveOutput.getCompletedInput());
+
+        return runner;
+    }
+
+    @Test
+    public void testPaleoRatesSetup() throws DocumentException, IOException {
+
+        // Approach: create two solutions: one with paleo rates enum, the other with the file that
+        // backs that enum value. Then see if they are equivalent.
+
+        NZSHM22_CrustalInversionRunner runner = makeRunner();
+        runner.setPaleoRateConstraints(0.4, 0.5, "PALEO_RI_GEOLOGIC_MAY24", "NZSHM22_C_42");
+        FaultSystemSolution solution = runner.runInversion();
+        PaleoseismicConstraintData constraints =
+                solution.getRupSet().getModule(PaleoseismicConstraintData.class);
+        List<? extends UncertainDataConstraint.SectMappedUncertainDataConstraint> paleoConstraints =
+                constraints.getPaleoRateConstraints();
+
+        runner = makeRunner();
+        runner.setPaleoRateConstraints(0.4, 0.5, "CUSTOM", "NZSHM22_C_42");
+        runner.setPaleoRatesFile(
+                "src/main/resources/paleoRates/NZNSHM_paleotimings_GEOLOGIC_24May.txt");
+        solution = runner.runInversion();
+        constraints = solution.getRupSet().getModule(PaleoseismicConstraintData.class);
+        List<? extends UncertainDataConstraint.SectMappedUncertainDataConstraint>
+                paleoFileConstraints = constraints.getPaleoRateConstraints();
+
+        for (int index = 0; index < paleoConstraints.size(); index++) {
+            UncertainDataConstraint.SectMappedUncertainDataConstraint fromEnum =
+                    paleoConstraints.get(index);
+            UncertainDataConstraint.SectMappedUncertainDataConstraint fromFile =
+                    paleoFileConstraints.get(index);
+
+            assertEquals(fromEnum.name, fromFile.name);
+            assertEquals(fromEnum.dataLocation, fromFile.dataLocation);
+            assertEquals(fromEnum.sectionIndex, fromFile.sectionIndex);
+        }
+    }
+}


### PR DESCRIPTION
closes #372 

It was cleaner to create a new method `setPaleoRatesFile()` rather than change the behaviour of the existing methods.

Now it is possible to specify a paleo rates file name and a `CUSTOM` paleo rates enum value:

```Java
        runner.setPaleoRateConstraints(0.4, 0.5, "CUSTOM", "NZSHM22_C_42");
        runner.setPaleoRatesFile("myCustomRates.txt");
```

This way, only the paleo rates from the file are used.

It is also possible to combine paleo rates from the enum and the file:

```Java
        runner.setPaleoRateConstraints(0.4, 0.5, "PALEO_RI_GEOLOGIC_MAY24", "NZSHM22_C_42");
        runner.setPaleoRatesFile("myExtraRates.txt");
```

The custom paleo rates file or the file name are not stored in the solution archive.