### PR TITLE
[390] remove BOM

### DIFF
--- a/src/main/resources/faultModels/cfm_0_9_d90_all.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9_d90_all.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	4
+Akatore	4
 Alpine: George to Jacksons	26
 Alpine: Jacksons to Kaniere	27
 Alpine: Kaniere to Springs Junction	28

--- a/src/main/resources/faultModels/cfm_0_9_d90_all_stirling_depths.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9_d90_all_stirling_depths.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	4
+Akatore	4
 Alpine: George to Jacksons	26
 Alpine: Jacksons to Kaniere	27
 Alpine: Kaniere to Springs Junction	28

--- a/src/main/resources/faultModels/cfm_0_9_d90_no_tvz.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9_d90_no_tvz.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	4
+Akatore	4
 Alpine: George to Jacksons	17
 Alpine: Jacksons to Kaniere	18
 Alpine: Kaniere to Springs Junction	19

--- a/src/main/resources/faultModels/cfm_0_9_d90_no_tvz_stirling_depths.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9_d90_no_tvz_stirling_depths.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	4
+Akatore	4
 Alpine: George to Jacksons	17
 Alpine: Jacksons to Kaniere	18
 Alpine: Kaniere to Springs Junction	19

--- a/src/main/resources/faultModels/cfm_0_9a_d90_all.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9a_d90_all.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	17
 Alpine: Jacksons to Kaniere	18
 Alpine: Kaniere to Springs Junction	19

--- a/src/main/resources/faultModels/cfm_0_9a_d90_no_tvz.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9a_d90_no_tvz.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	12
 Alpine: Jacksons to Kaniere	13
 Alpine: Kaniere to Springs Junction	14

--- a/src/main/resources/faultModels/cfm_0_9c_d90_all.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9c_d90_all.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	17
 Alpine: Jacksons to Kaniere	18
 Alpine: Kaniere to Springs Junction	19

--- a/src/main/resources/faultModels/cfm_0_9c_d90_all_stirling_depths.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9c_d90_all_stirling_depths.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	17
 Alpine: Jacksons to Kaniere	18
 Alpine: Kaniere to Springs Junction	19

--- a/src/main/resources/faultModels/cfm_0_9c_d90_no_tvz.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9c_d90_no_tvz.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	12
 Alpine: Jacksons to Kaniere	13
 Alpine: Kaniere to Springs Junction	14

--- a/src/main/resources/faultModels/cfm_0_9c_d90_no_tvz_stirling_depths.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9c_d90_no_tvz_stirling_depths.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	12
 Alpine: Jacksons to Kaniere	13
 Alpine: Kaniere to Springs Junction	14

--- a/src/main/resources/faultModels/cfm_0_9d_d90_all.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9d_d90_all.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	17
 Alpine: Jacksons to Kaniere	18
 Alpine: Kaniere to Springs Junction	19

--- a/src/main/resources/faultModels/cfm_0_9d_d90_no_tvz.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_0_9d_d90_no_tvz.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	12
 Alpine: Jacksons to Kaniere	13
 Alpine: Kaniere to Springs Junction	14

--- a/src/main/resources/faultModels/cfm_1_0A_all.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_1_0A_all.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	17
 Alpine: Jacksons to Kaniere	18
 Alpine: Kaniere to Springs Junction	19

--- a/src/main/resources/faultModels/cfm_1_0A_no_tvz.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_1_0A_no_tvz.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	12
 Alpine: Jacksons to Kaniere	13
 Alpine: Kaniere to Springs Junction	14

--- a/src/main/resources/faultModels/cfm_1_0_domain_all.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_1_0_domain_all.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	17
 Alpine: Jacksons to Kaniere	18
 Alpine: Kaniere to Springs Junction	19

--- a/src/main/resources/faultModels/cfm_1_0_domain_no_tvz.xml.FaultsByNameAlt.txt
+++ b/src/main/resources/faultModels/cfm_1_0_domain_no_tvz.xml.FaultsByNameAlt.txt
@@ -1,4 +1,4 @@
-﻿Akatore	3
+Akatore	3
 Alpine: George to Jacksons	12
 Alpine: Jacksons to Kaniere	13
 Alpine: Kaniere to Springs Junction	14

--- a/src/main/resources/faultModels/namedFaultDefinitions.csv
+++ b/src/main/resources/faultModels/namedFaultDefinitions.csv
@@ -1,4 +1,4 @@
-﻿Akatore,Akatore
+Akatore,Akatore
 Alpine: George to Jacksons,Alpine: George to Jacksons
 Alpine: Jacksons to Kaniere,Alpine: Jacksons to Kaniere
 Alpine: Kaniere to Springs Junction,Alpine: Kaniere to Springs Junction


### PR DESCRIPTION
closes #390 

This is a Byte Order Mark that some Windows tools automatically add to the beginning of text documents. https://en.wikipedia.org/wiki/Byte_order_mark

It's invisible if you're not looking for it, and it breaks tools that don't expect it.

This problem only affected the name of the `Akatore` named fault. The impact is so minor that I do not believe that we need to create new versions of these files.

We can use `grep` and `find` to detect and fix files. These regexes are not perfect and may find false positives. Text files are safe to modify with this method.

```
root@2ab3cf3579fa:/nzshm-opensha/src# grep -rl $'\xEF\xBB\xBF' .
./main/resources/faultModels/cfm_0_9a_d90_all.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9a_d90_no_tvz.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9c_d90_all.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9c_d90_all_stirling_depths.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9c_d90_no_tvz.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9c_d90_no_tvz_stirling_depths.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9d_d90_all.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9d_d90_no_tvz.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9_d90_all.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9_d90_all_stirling_depths.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9_d90_no_tvz.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_0_9_d90_no_tvz_stirling_depths.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_1_0A_all.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_1_0A_no_tvz.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_1_0_domain_all.xml.FaultsByNameAlt.txt
./main/resources/faultModels/cfm_1_0_domain_no_tvz.xml.FaultsByNameAlt.txt
./main/resources/faultModels/namedFaultDefinitions.csv
root@2ab3cf3579fa:/nzshm-opensha/src# find . -type f -exec sed '1s/^\xEF\xBB\xBF//' -i {} \;
root@2ab3cf3579fa:/nzshm-opensha/src# grep -rl $'\xEF\xBB\xBF' .
```