### PR TITLE
[439] Joint scaling relationship

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/PartitionConfig.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/PartitionConfig.java
@@ -1,0 +1,96 @@
+package nz.cri.gns.NZSHM22.opensha.inversion.joint;
+
+import java.util.*;
+import java.util.function.IntPredicate;
+import java.util.stream.Collectors;
+import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_DeformationModel;
+import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_MagBounds;
+import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_SpatialSeisPDF;
+import nz.cri.gns.NZSHM22.opensha.inversion.AbstractInversionConfiguration;
+import org.opensha.commons.data.uncertainty.UncertainIncrMagFreqDist;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+
+public class PartitionConfig {
+
+    public final PartitionPredicate partition;
+
+    public transient List<Integer> sectionIds;
+    public transient Map<Integer, Integer> mappingToARow;
+    public transient IntPredicate partitionPredicate;
+
+    // slip rate section
+    public double slipRateConstraintWt_normalized = 1;
+    public double slipRateConstraintWt_unnormalized = 100;
+    public AbstractInversionConfiguration.NZSlipRateConstraintWeightingType slipRateWeightingType =
+            AbstractInversionConfiguration.NZSlipRateConstraintWeightingType.BOTH;
+    public double slipRateUncertaintyConstraintWt;
+    public double slipRateUncertaintyConstraintScalingFactor;
+    public boolean unmodifiedSlipRateStdvs;
+    public NZSHM22_DeformationModel deformationModel = NZSHM22_DeformationModel.FAULT_MODEL;
+
+    // MFD section
+    public double totalRateM5;
+    public double bValue;
+    public double minMag;
+    // only required for crustal
+    public double maxMag;
+    // only required for crustal
+    public NZSHM22_MagBounds.MaxMagType maxMagType = NZSHM22_MagBounds.MaxMagType.NONE;
+    public double mfdTransitionMag;
+    public double mfdEqualityConstraintWt;
+    public double mfdInequalityConstraintWt;
+    public double mfdUncertaintyWeight;
+    public double mfdUncertaintyPower;
+    public double mfdUncertaintyScalar;
+    // crustal only
+    public NZSHM22_SpatialSeisPDF spatialSeisPDF;
+    // crustal only
+    public double polygonBufferSize;
+    // crustal only
+    public double polygonMinBufferSize;
+
+    public transient List<IncrementalMagFreqDist> mfdConstraints;
+    public transient List<UncertainIncrMagFreqDist> mfdUncertaintyWeightedConstraints;
+
+    public PartitionConfig(PartitionPredicate partition) {
+        this.partition = partition;
+    }
+
+    public void init(FaultSystemRupSet ruptureSet) {
+        partitionPredicate = partition.getPredicate(ruptureSet);
+        sectionIds =
+                ruptureSet.getFaultSectionDataList().stream()
+                        .mapToInt(FaultSection::getSectionId)
+                        .filter(partitionPredicate)
+                        .boxed()
+                        .collect(Collectors.toList());
+        mappingToARow = new HashMap<>();
+        for (int i = 0; i < sectionIds.size(); i++) {
+            mappingToARow.put(sectionIds.get(i), i);
+        }
+    }
+
+    /**
+     * Returns true if this config covers the specified section id.
+     *
+     * @param sectionId
+     * @return
+     */
+    public boolean covers(int sectionId) {
+        return partitionPredicate.test(sectionId);
+    }
+
+    public List<Integer> getSectionIds() {
+        return sectionIds;
+    }
+
+    public int getNumSections() {
+        return sectionIds.size();
+    }
+
+    public int mapToRow(int sectionId) {
+        return mappingToARow.get(sectionId);
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/RuptureSetSetup.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/RuptureSetSetup.java
@@ -1,0 +1,100 @@
+package nz.cri.gns.NZSHM22.opensha.inversion.joint;
+
+import java.io.IOException;
+import java.util.function.IntPredicate;
+import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_FaultModels;
+import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_LogicTreeBranch;
+import nz.cri.gns.NZSHM22.opensha.ruptures.CustomFaultModel;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.modules.AveSlipModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.FaultGridAssociations;
+import org.opensha.sha.earthquake.faultSysSolution.modules.SectSlipRates;
+import org.opensha.sha.faultSurface.FaultSection;
+
+public class RuptureSetSetup {
+
+    public static void applyScalingRelationship(Config config) {
+        if (config.scalingRelationship != null && config.recalcMags) {
+            double[] mags = config.ruptureSet.getMagForAllRups();
+            double[] aveSlips = new double[mags.length];
+            IntPredicate isCrustal = PartitionPredicate.CRUSTAL.getPredicate(config.ruptureSet);
+            for (int rupture = 0; rupture < mags.length; rupture++) {
+                double aveRake = config.ruptureSet.getAveRakeForRup(rupture);
+                double crustalArea = 0;
+                double subductionArea = 0;
+                for (FaultSection section :
+                        config.ruptureSet.getFaultSectionDataForRupture(rupture)) {
+                    if (isCrustal.test(section.getSectionId())) {
+                        crustalArea += section.getArea(true);
+                    } else {
+                        subductionArea += section.getArea(true);
+                    }
+                }
+                mags[rupture] =
+                        config.scalingRelationship.getMag(crustalArea, subductionArea, aveRake);
+                aveSlips[rupture] =
+                        config.scalingRelationship.getAveSlip(crustalArea, subductionArea, aveRake);
+            }
+            config.ruptureSet.removeModuleInstances(AveSlipModule.class);
+            config.ruptureSet.addModule(AveSlipModule.precomputed(config.ruptureSet, aveSlips));
+        }
+    }
+
+    protected static void applyDeformationModel(Config config) {
+
+        FaultSystemRupSet ruptureSet = config.ruptureSet;
+        for (PartitionConfig partition : config.partitions) {
+            partition.deformationModel.applyTo(ruptureSet, partition.partitionPredicate);
+        }
+        SectSlipRates rates = SectSlipRates.fromFaultSectData(ruptureSet);
+        ruptureSet.addModule(
+                SectSlipRates.precomputed(
+                        ruptureSet, rates.getSlipRates(), rates.getSlipRateStdDevs()));
+    }
+
+    protected static void applySlipRateFactor(
+            PartitionPredicate region, double slipRateFactor, FaultSystemRupSet rupSet) {
+        if (slipRateFactor < 0) {
+            return;
+        }
+        IntPredicate inRegion = region.getPredicate(rupSet);
+        SectSlipRates origSlips = rupSet.getModule(SectSlipRates.class);
+        double[] slipRates = origSlips.getSlipRates();
+
+        for (int i = 0; i < slipRates.length; i++) {
+            if (inRegion.test(i)) {
+                slipRates[i] *= slipRateFactor;
+            }
+        }
+        rupSet.addModule(
+                SectSlipRates.precomputed(rupSet, slipRates, origSlips.getSlipRateStdDevs()));
+    }
+
+    /**
+     * Sets up the various required modules of the rupture set
+     *
+     * @param config
+     * @throws IOException
+     */
+    public static void setup(Config config) throws IOException {
+
+        FaultSystemRupSet ruptureSet = config.ruptureSet;
+        ruptureSet.removeModuleInstances(FaultGridAssociations.class);
+        ruptureSet.removeModuleInstances(SectSlipRates.class);
+
+        applyScalingRelationship(config);
+
+        // TODO: do we actually need a fault model? does this make sense for joint ruptures?
+        CustomFaultModel customFaultModel = ruptureSet.getModule(CustomFaultModel.class);
+        if (customFaultModel != null) {
+            NZSHM22_LogicTreeBranch ltb = ruptureSet.getModule(NZSHM22_LogicTreeBranch.class);
+            NZSHM22_FaultModels faultModel = ltb.getValue(NZSHM22_FaultModels.class);
+            faultModel.setCustomModel(customFaultModel.getModelData());
+        }
+
+        applyDeformationModel(config);
+
+        applySlipRateFactor(PartitionPredicate.TVZ, config.tvzSlipRateFactor, ruptureSet);
+        applySlipRateFactor(PartitionPredicate.SANS_TVZ, config.sansSlipRateFactor, ruptureSet);
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/scaling/EstimatedJointScalingRelationship.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/scaling/EstimatedJointScalingRelationship.java
@@ -1,0 +1,21 @@
+package nz.cri.gns.NZSHM22.opensha.inversion.joint.scaling;
+
+/**
+ * Based on Bruce Shaw's suggestion. See
+ * https://github.com/voj/science-playground/blob/f9e56b3efd24b5150e4e6ee493b1744ce8d8eb50/WORKDIR/magnitude.ipynb
+ */
+public class EstimatedJointScalingRelationship implements JointScalingRelationship {
+
+    double crustal;
+    double subduction;
+
+    public EstimatedJointScalingRelationship() {
+        crustal = 1e-6 * Math.pow(10, 4.2);
+        subduction = 1e-6 * Math.pow(10, 4.0);
+    }
+
+    @Override
+    public double getMag(double crustalArea, double subductionArea, double aveRake) {
+        return Math.log10(subductionArea * subduction + crustalArea * crustal);
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/scaling/JointScalingRelationship.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/scaling/JointScalingRelationship.java
@@ -1,0 +1,29 @@
+package nz.cri.gns.NZSHM22.opensha.inversion.joint.scaling;
+
+import org.opensha.commons.calc.FaultMomentCalc;
+import org.opensha.commons.eq.MagUtils;
+
+public interface JointScalingRelationship {
+
+    /**
+     * This returns the slip (m) for the given rupture area (m-sq) or rupture length (m)
+     *
+     * @param area (m-sq)
+     * @param aveRake average rake of this rupture
+     * @return
+     */
+    default double getAveSlip(double crustalArea, double subductionArea, double aveRake) {
+        double mag = getMag(crustalArea, subductionArea, aveRake);
+        double moment = MagUtils.magToMoment(mag);
+        return FaultMomentCalc.getSlip(crustalArea + subductionArea, moment);
+    }
+
+    /**
+     * This returns the magnitude for the given rupture area (m-sq) and width (m)
+     *
+     * @param area (m-sq)
+     * @param aveRake average rake of this rupture
+     * @return
+     */
+    double getMag(double crustalArea, double subductionArea, double aveRake);
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/scaling/SimplifiedJointScalingRelationship.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/scaling/SimplifiedJointScalingRelationship.java
@@ -1,0 +1,17 @@
+package nz.cri.gns.NZSHM22.opensha.inversion.joint.scaling;
+
+import nz.cri.gns.NZSHM22.opensha.calc.SimplifiedScalingRelationship;
+
+public class SimplifiedJointScalingRelationship implements JointScalingRelationship {
+
+    SimplifiedScalingRelationship simplified;
+
+    public SimplifiedJointScalingRelationship(SimplifiedScalingRelationship simplified) {
+        this.simplified = simplified;
+    }
+
+    @Override
+    public double getMag(double crustalArea, double subductionArea, double aveRake) {
+        return simplified.getMag(crustalArea + subductionArea, 0, 0, 0, aveRake);
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/util/TraceTool.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/util/TraceTool.java
@@ -1,0 +1,28 @@
+package nz.cri.gns.NZSHM22.util;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Utility to find out call sites for a method. Add TraceTool.trace() to the method you want to
+ * trace. Call TraceTool.getTraces() before shutdown.
+ */
+public class TraceTool {
+
+    static Set<String> traces = new HashSet<>();
+
+    public static void trace() {
+        String trace =
+                Arrays.stream(Thread.currentThread().getStackTrace())
+                        .skip(2)
+                        .map(Object::toString)
+                        .collect(Collectors.joining("\n"));
+        traces.add(trace);
+    }
+
+    public static String getTraces() {
+        return String.join("\n\n", traces);
+    }
+}


### PR DESCRIPTION
closes #439 

- Sets up a way to calculate joint scaling relationships. Wraps simplified SR used by NZSHM so it can also be used in the new setup.
- We actually only use scaling relationhips in very few places: to calculate magnitude and to calculate ave slip. In the new code this is now done in `RuptureSetSetup.applyScalingRelationship()`
- In order for you to see how the scaling relationship is used, I've included `Config`, `PartitionConfig`, and `RuptureSetSetup`.
   - `Config` is the overall config and includes the scaling relationship. 
   - `PartitionConfig` is the config for a partiton (i.e. `CRUSTAL`, `HIKURANGI`, etc). 
   - These two configs are mostly data objects that map straight to JSON and have little other functionality. However, `Config` has a step to hydrate the scaling relationship.
   - Once the config is hydrated, `RuptureSetSetup` takes care of magnitudes and modules. 

These three objects are taken a little out of context (meaning this won't quite compile yet), but I've included them to show how the SR is used. This will also lighten the load for the big PR nextweek.

- `TraceTool` is a little tool that produced the stack traces in the description of#439