### PR TITLE
[461] Reinstate Tabular MFDs

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/enumTreeBranches/NZSHM22_FaultModels.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/enumTreeBranches/NZSHM22_FaultModels.java
@@ -155,7 +155,7 @@ public enum NZSHM22_FaultModels implements LogicTreeNode {
     SBD_0_3_HKR_LR_30(
             "Hikurangi, Kermadec to Louisville ridge, 30km - with slip deficit smoothed near East Cape and locked near trench.",
             "hk_tile_parameters_locked_trench_slip_deficit_v2_30.csv",
-            20000,
+            10000,
             PartitionPredicate.HIKURANGI),
     @Deprecated
     SBD_0_4_HKR_LR_30(

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
@@ -10,7 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.*;
-import nz.cri.gns.NZSHM22.opensha.reports.ExtraData;
+import nz.cri.gns.NZSHM22.opensha.reports.TabularMfds;
 import nz.cri.gns.NZSHM22.opensha.ruptures.NZSHM22_AbstractRuptureSetBuilder;
 import nz.cri.gns.NZSHM22.opensha.util.SimpleGeoJsonBuilder;
 import org.dom4j.DocumentException;
@@ -939,15 +939,6 @@ public abstract class NZSHM22_AbstractInversionRunner {
         double[] solution_adjusted =
                 inversionInputGenerator.adjustSolutionForWaterLevel(solution_raw);
 
-        //		Map<ConstraintRange, Double> energies = tsa.getEnergies();
-        //		if (energies != null) {
-        //			System.out.println("Final energies:");
-        //			for (ConstraintRange range : energies.keySet()) {
-        //				finalEnergies.put(range.name, (double) energies.get(range).floatValue());
-        //				System.out.println("\t" + range.name + ": " + energies.get(range).floatValue());
-        //			}
-        //		}
-
         Set<Integer> zeroRates = new HashSet<>();
         for (int r = 0; r < solution_adjusted.length; r++) {
             if (solution_adjusted[r] == 0) {
@@ -965,11 +956,12 @@ public abstract class NZSHM22_AbstractInversionRunner {
         return solution;
     }
 
-    public  ArrayList<ArrayList<String>> getTabularSolutionMfds(){
-        return ExtraData.getTabularSolutionMfds(solution);
-    }
-    public ArrayList<ArrayList<String>> getTabularSolutionMfdsV2() {
-        return ExtraData.getTabularSolutionMfdsV2(solution);
+    public List<List<String>> getTabularSolutionMfds() {
+        return TabularMfds.getTabularSolutionMfds(
+                solution, scalingRelationship.getRegime() == FaultRegime.CRUSTAL);
     }
 
+    public List<List<String>> getTabularSolutionMfdsV2() {
+        return TabularMfds.getTabularSolutionMfdsV2(solution);
+    }
 }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/FaultSectionProperties.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/FaultSectionProperties.java
@@ -351,18 +351,9 @@ public class FaultSectionProperties {
      * @throws DocumentException if parsing of any XML/GeoJSON documents fails
      */
     @SuppressWarnings("unchecked")
-    public static void backfill() throws IOException, DocumentException {
+    public static void backfill(String archiveFileName) throws IOException, DocumentException {
 
-        String ruptureSetName =
-                "C:\\Users\\volkertj\\Code\\ruptureSets\\mergedRupset_5km_cffPatch2km_cff0SelfStiffness.zip";
-        //        ruptureSetName =
-        //
-        // "C:\\Users\\volkertj\\Code\\ruptureSets\\NZSHM22_RuptureSet-UnVwdHVyZUdlbmVyYXRpb25UYXNrOjEwMDAzOA==.zip";
-        //        ruptureSetName =
-        //
-        // "C:\\Users\\volkertj\\Code\\ruptureSets\\RupSet_Sub_FM(SBD_0_3_HKR_LR_30)_mnSbS(2)_mnSSPP(2)_mxSSL(0.5)_ddAsRa(2.0,5.0,5)_ddMnFl(0.1)_ddPsCo(0.0)_ddSzCo(0.0)_thFc(0.0).zip";
-
-        FaultSystemRupSet ruptureSet = FaultSystemRupSet.load(new File(ruptureSetName));
+        FaultSystemRupSet ruptureSet = FaultSystemRupSet.load(new File(archiveFileName));
 
         // faultmodel is only used for crustal sections
         NZSHM22_FaultModels crustalFaultModel = NZSHM22_FaultModels.CFM_1_0A_DOM_SANSTVZ;
@@ -418,7 +409,7 @@ public class FaultSectionProperties {
             }
         }
 
-        ruptureSet.write(new File(ruptureSetName + "props4.zip"));
+        ruptureSet.write(new File(archiveFileName + "props4.zip"));
     }
 
     /**
@@ -430,6 +421,16 @@ public class FaultSectionProperties {
      * @throws DocumentException if there is an issue parsing XML/geojson documents
      */
     public static void main(String[] args) throws IOException, DocumentException {
-        backfill();
+        String ruptureSetName =
+                //
+                // "C:\\Users\\volkertj\\Code\\ruptureSets\\mergedRupset_5km_cffPatch2km_cff0SelfStiffness.zip";
+                //        ruptureSetName =
+                //
+                // "C:\\Users\\volkertj\\Code\\ruptureSets\\NZSHM22_RuptureSet-UnVwdHVyZUdlbmVyYXRpb25UYXNrOjEwMDAzOA==.zip";
+                //        ruptureSetName =
+                //
+                "C:\\Users\\volkertj\\Code\\ruptureSets\\RupSet_Sub_FM(SBD_0_3_HKR_LR_30)_mnSbS(2)_mnSSPP(2)_mxSSL(0.5)_ddAsRa(2.0,5.0,5)_ddMnFl(0.1)_ddPsCo(0.0)_ddSzCo(0.0)_thFc(0.0).zip";
+
+        backfill(ruptureSetName);
     }
 }


### PR DESCRIPTION
closes #461 

- We worked out that `getSolutionMetrics()` is no longer needed, The call from `runzi` is to be deleted.
- Fixed a stray 20000 parent id for a Hikurangi fault model, as it caused the NZSHM22 Hikurangi rupture set to be misaligned with its deformation model after converting to the modular archive format - as discovered while testing.