### PR TITLE
[479] Joint Rupture Rates Report

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -1,0 +1,79 @@
+# Ubiquitous Language
+
+## Seismic model structure
+
+| Term | Definition | Aliases to avoid |
+| ---- | ---------- | ---------------- |
+| **Rupture Set** | A collection of all possible earthquake ruptures on a set of faults | Rup set |
+| **Rupture** | A single hypothetical earthquake event defined by which fault sections break together | Event, earthquake |
+| **Fault Section** | A discrete segment of a fault surface used as a building block for ruptures | Section, subsection, fault segment |
+| **Fault** | A geological fracture along which displacement occurs | |
+| **Solution** | The result of an inversion: a rupture set with assigned annual rates for each rupture | Inversion result |
+| **Inversion** | The process of solving for rupture rates that satisfy slip-rate and MFD constraints via simulated annealing | |
+
+## Partitions and tectonic domains
+
+| Term | Definition | Aliases to avoid |
+| ---- | ---------- | ---------------- |
+| **Partition** | A tectonic grouping of fault sections (CRUSTAL, HIKURANGI, PUYSEGUR, TVZ, SANS_TVZ) | Region, domain, zone |
+| **Crustal** | The shallow tectonic domain encompassing all non-subduction faults (TVZ + SANS_TVZ) | |
+| **Subduction** | A tectonic domain where one plate descends beneath another (HIKURANGI or PUYSEGUR) | Interface |
+| **Joint Rupture** | A rupture whose fault sections span more than one partition (e.g. crustal + subduction) | Shared rupture, multi-partition rupture |
+| **Exclusive Rupture** | A rupture whose fault sections all belong to a single partition | Single-partition rupture |
+
+## Rates and distributions
+
+| Term | Definition | Aliases to avoid |
+| ---- | ---------- | ---------------- |
+| **MFD** | Magnitude-Frequency Distribution: the rate of earthquakes as a function of magnitude | Magnitude distribution |
+| **Incremental MFD** | An MFD giving the rate within each discrete magnitude bin | |
+| **Cumulative MFD** | An MFD giving the rate of earthquakes at or above each magnitude | |
+| **Rate** | The expected annual frequency of occurrence of a rupture | Frequency, probability |
+| **Slip Rate** | The long-term rate of displacement on a fault section, used as an inversion constraint | |
+
+## Magnitude and area
+
+| Term | Definition | Aliases to avoid |
+| ---- | ---------- | ---------------- |
+| **Magnitude** | A measure of earthquake energy release (moment magnitude scale) | Mag |
+| **Scaling Relation** | A formula relating rupture area (or length) to magnitude | Mag-area relation |
+| **Crustal Area Fraction** | The proportion of a joint rupture's total area contributed by crustal fault sections | Area ratio |
+
+## Reporting and analysis
+
+| Term | Definition | Aliases to avoid |
+| ---- | ---------- | ---------------- |
+| **Report Plot** | A class extending AbstractRupSetPlot that generates a PNG chart and returns markdown for inclusion in a report | Plot, chart |
+| **Partition Plot Wrapper** | A decorator that runs an existing report plot once per partition | |
+| **Comparison** | A second rupture set or solution shown alongside the primary one for side-by-side analysis | Reference model |
+
+## Relationships
+
+- A **Rupture Set** contains many **Ruptures**
+- Each **Rupture** consists of one or more **Fault Sections**
+- Each **Fault Section** belongs to exactly one **Partition**
+- A **Joint Rupture** spans exactly two **Partitions** (one crustal, one subduction)
+- An **Exclusive Rupture** belongs to exactly one **Partition**
+- A **Solution** assigns a **Rate** to every **Rupture** in a **Rupture Set**
+- An **MFD** is derived from a **Solution** by binning **Rates** by **Magnitude**
+- A **Cumulative MFD** is derived from an **Incremental MFD**
+
+## Example dialogue
+
+> **Dev:** "When we compute the **Crustal Area Fraction** for a **Joint Rupture**, do we sum by **Fault Section** or use `getAreaForRup`?"
+
+> **Domain expert:** "By **Fault Section**. Loop through each section in the **Rupture**, check which **Partition** it belongs to, and sum `getAreaForSection`. Then divide the crustal total by the overall total."
+
+> **Dev:** "And an **Exclusive Rupture** wouldn't appear in this histogram at all?"
+
+> **Domain expert:** "Correct. Only **Joint Ruptures** have a meaningful fraction -- they span both crustal and subduction **Partitions**. An **Exclusive Rupture** would be trivially 0 or 1."
+
+> **Dev:** "For the **Cumulative MFD** chart, should we compute it from the **Incremental MFD** or directly from the **Solution**?"
+
+> **Domain expert:** "From the **Incremental MFD**. Call `getCumRateDistWithOffset()` on each per-category **Incremental MFD**. That keeps the two charts consistent."
+
+## Flagged ambiguities
+
+- **"Region"** was not used in this conversation but appears in the codebase (`NewZealandRegions`, `calcNucleationMFD_forRegion`). A **Region** is a geographic boundary, distinct from a **Partition** which is a tectonic classification of fault sections. Do not conflate the two.
+- **"Shared rupture"** appeared in `PartitionSummaryTable` field names (`sharedCounts`) as a synonym for **Joint Rupture**. Prefer **Joint Rupture** in domain discussions; the code uses "shared" internally but the report labels say "Joint".
+- **"Area ratio"** vs **"Crustal Area Fraction"**: the plot file prefix uses `joint_area_ratio` but the concept is a fraction in [0, 1], not a ratio. Prefer **Crustal Area Fraction** in prose; the file name is a historical artifact.

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -1,25 +1,28 @@
 # Ubiquitous Language
 
+The "aliases to avoid" column can also be used to look up definitions if these aliases as still accidentally used.
+
 ## Seismic model structure
 
-| Term | Definition | Aliases to avoid |
-| ---- | ---------- | ---------------- |
-| **Rupture Set** | A collection of all possible earthquake ruptures on a set of faults | Rup set |
-| **Rupture** | A single hypothetical earthquake event defined by which fault sections break together | Event, earthquake |
-| **Fault Section** | A discrete segment of a fault surface used as a building block for ruptures | Section, subsection, fault segment |
-| **Fault** | A geological fracture along which displacement occurs | |
-| **Solution** | The result of an inversion: a rupture set with assigned annual rates for each rupture | Inversion result |
-| **Inversion** | The process of solving for rupture rates that satisfy slip-rate and MFD constraints via simulated annealing | |
+| Term              | Definition                                                                                                  | Aliases to avoid       |
+|-------------------|-------------------------------------------------------------------------------------------------------------|------------------------|
+| **Rupture Set**   | A collection of all possible earthquake ruptures on a set of faults                                         |                        |
+| **Rupture**       | A single hypothetical earthquake event defined by which fault sections break together                       | Event, earthquake      |
+| **Fault Section** | A discrete segment of a fault surface used as a building block for ruptures                                 | Section, fault segment |
+| **Sub Section**   | A subdivision of a fault section                                                                           |                        |
+| **Fault**         | A geological fracture along which displacement occurs                                                       |                        |
+| **Solution**      | The result of an inversion: a rupture set with assigned annual rates for each rupture                       | Inversion result       |
+| **Inversion**     | The process of solving for rupture rates that satisfy slip-rate and MFD constraints via simulated annealing |                        |
 
 ## Partitions and tectonic domains
 
-| Term | Definition | Aliases to avoid |
-| ---- | ---------- | ---------------- |
-| **Partition** | A tectonic grouping of fault sections (CRUSTAL, HIKURANGI, PUYSEGUR, TVZ, SANS_TVZ) | Region, domain, zone |
-| **Crustal** | The shallow tectonic domain encompassing all non-subduction faults (TVZ + SANS_TVZ) | |
-| **Subduction** | A tectonic domain where one plate descends beneath another (HIKURANGI or PUYSEGUR) | Interface |
-| **Joint Rupture** | A rupture whose fault sections span more than one partition (e.g. crustal + subduction) | Shared rupture, multi-partition rupture |
-| **Exclusive Rupture** | A rupture whose fault sections all belong to a single partition | Single-partition rupture |
+| Term | Definition                                                                                                                        | Aliases to avoid |
+| ---- |-----------------------------------------------------------------------------------------------------------------------------------| ---------------- |
+| **Partition** | A tectonic grouping of fault sections (CRUSTAL, HIKURANGI, PUYSEGUR, TVZ, SANS_TVZ)                                               | Region, domain, zone |
+| **Crustal** | The shallow tectonic domain encompassing all non-subduction faults (TVZ + SANS_TVZ)                                               | |
+| **Subduction** | Fault network created by the the interface between two plates where one is subducting beneith the other (HIKURANGI or PUYSEGUR) | Interface |
+| **Joint Rupture** | A rupture whose fault sections span more than one partition (e.g. crustal + subduction)                                           | Shared rupture, multi-partition rupture |
+| **Exclusive Rupture** | A rupture whose fault sections all belong to a single partition                                                                   | Single-partition rupture |
 
 ## Rates and distributions
 
@@ -35,7 +38,7 @@
 
 | Term | Definition | Aliases to avoid |
 | ---- | ---------- | ---------------- |
-| **Magnitude** | A measure of earthquake energy release (moment magnitude scale) | Mag |
+| **Magnitude** | Moment magnitude; a logarithmic measure of earthquake size, related to total energy of the earthquake. | Mag |
 | **Scaling Relation** | A formula relating rupture area (or length) to magnitude | Mag-area relation |
 | **Crustal Area Fraction** | The proportion of a joint rupture's total area contributed by crustal fault sections | Area ratio |
 
@@ -55,8 +58,7 @@
 - A **Joint Rupture** spans exactly two **Partitions** (one crustal, one subduction)
 - An **Exclusive Rupture** belongs to exactly one **Partition**
 - A **Solution** assigns a **Rate** to every **Rupture** in a **Rupture Set**
-- An **MFD** is derived from a **Solution** by binning **Rates** by **Magnitude**
-- A **Cumulative MFD** is derived from an **Incremental MFD**
+- An **MFD** can be used to create inversion constraints. It can also be derived from a **Solution** by binning **Rates** by **Magnitude** A **Cumulative MFD** is derived from an **Incremental MFD**
 
 ## Example dialogue
 

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlot.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlot.java
@@ -141,9 +141,32 @@ public class JointRuptureRatePlot extends AbstractRupSetPlot {
             for (int b = 0; b < numBins; b++) {
                 func.set(b, bins[b]);
             }
-            func.setName(cat);
+            String legend = cat.contains("+") ? cat : cat + " only";
+            func.setName(legend);
             funcs.add(func);
             chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, COLORS.get(i)));
+        }
+
+        // Find smallest nonzero y value across all curves
+        double minNonZeroY = Double.MAX_VALUE;
+        for (DiscretizedFunc func : funcs) {
+            for (int b = 0; b < func.size(); b++) {
+                double y = func.getY(b);
+                if (y > 0 && y < minNonZeroY) {
+                    minNonZeroY = y;
+                }
+            }
+        }
+        Range yRange = null;
+        if (minNonZeroY < Double.MAX_VALUE) {
+            // Find max y for upper bound
+            double maxY = 0;
+            for (DiscretizedFunc func : funcs) {
+                for (int b = 0; b < func.size(); b++) {
+                    maxY = Math.max(maxY, func.getY(b));
+                }
+            }
+            yRange = new Range(minNonZeroY / 10.0, maxY * 2.0);
         }
 
         PlotSpec spec =
@@ -162,7 +185,7 @@ public class JointRuptureRatePlot extends AbstractRupSetPlot {
 
         HeadlessGraphPanel gp = PlotUtils.initHeadless(PlotPreferences.getDefaultAppPrefs());
         gp.setTickLabelFontSize(20);
-        gp.drawGraphPanel(spec, false, true, xRange, null);
+        gp.drawGraphPanel(spec, false, true, xRange, yRange);
 
         String prefix = "joint_rupture_mfds";
         PlotUtils.writePlots(resourcesDir, prefix, gp, 1000, 850, true, true, false);

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlot.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlot.java
@@ -10,6 +10,8 @@ import org.jfree.data.Range;
 import org.opensha.commons.data.function.DiscretizedFunc;
 import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
 import org.opensha.commons.gui.plot.*;
+import org.opensha.commons.util.MarkdownUtils;
+import org.opensha.commons.util.MarkdownUtils.TableBuilder;
 import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
@@ -80,6 +82,61 @@ public class JointRuptureRatePlot extends AbstractRupSetPlot {
         public double rateSum;
     }
 
+    /**
+     * Computes a log-scale y-range from the given functions. Returns null if all values are zero.
+     *
+     * @param funcs the functions to scan
+     * @return y-range with padding, or null if no positive values
+     */
+    protected static Range computeLogYRange(List<DiscretizedFunc> funcs) {
+        double minNonZeroY = Double.MAX_VALUE;
+        double maxY = 0;
+        for (DiscretizedFunc func : funcs) {
+            for (int b = 0; b < func.size(); b++) {
+                double y = func.getY(b);
+                if (y > 0) {
+                    if (y < minNonZeroY) minNonZeroY = y;
+                    if (y > maxY) maxY = y;
+                }
+            }
+        }
+        if (minNonZeroY == Double.MAX_VALUE) return null;
+        return new Range(minNonZeroY / 10.0, maxY * 2.0);
+    }
+
+    /**
+     * Writes an MFD plot (incremental or cumulative) to disk.
+     *
+     * @param funcs the data series
+     * @param chars the line characteristics for each series
+     * @param title plot title
+     * @param yLabel y-axis label
+     * @param xRange x-axis range
+     * @param resourcesDir output directory
+     * @param prefix file name prefix
+     * @throws IOException if writing fails
+     */
+    protected static void writeMFDPlot(
+            List<DiscretizedFunc> funcs,
+            List<PlotCurveCharacterstics> chars,
+            String title,
+            String yLabel,
+            Range xRange,
+            File resourcesDir,
+            String prefix)
+            throws IOException {
+        PlotSpec spec = new PlotSpec(funcs, chars, title, "Magnitude", yLabel);
+        spec.setLegendInset(true);
+
+        Range yRange = computeLogYRange(funcs);
+
+        HeadlessGraphPanel gp = PlotUtils.initHeadless(PlotPreferences.getDefaultAppPrefs());
+        gp.setTickLabelFontSize(20);
+        gp.drawGraphPanel(spec, false, true, xRange, yRange);
+
+        PlotUtils.writePlots(resourcesDir, prefix, gp, 1000, 850, true, true, false);
+    }
+
     @Override
     public String getName() {
         return "Joint Rupture Rates";
@@ -129,70 +186,73 @@ public class JointRuptureRatePlot extends AbstractRupSetPlot {
             }
         }
 
-        // Build MFD functions
-        List<DiscretizedFunc> funcs = new ArrayList<>();
-        List<PlotCurveCharacterstics> chars = new ArrayList<>();
+        // Build incremental MFD functions
+        List<IncrementalMagFreqDist> incrMFDs = new ArrayList<>();
+        List<DiscretizedFunc> incrFuncs = new ArrayList<>();
+        List<PlotCurveCharacterstics> incrChars = new ArrayList<>();
         for (int i = 0; i < CATEGORIES.size(); i++) {
             String cat = CATEGORIES.get(i);
             double[] bins = rateBins.get(cat);
-            EvenlyDiscretizedFunc func =
-                    new EvenlyDiscretizedFunc(
+            IncrementalMagFreqDist func =
+                    new IncrementalMagFreqDist(
                             templateMFD.getMinX(), numBins, templateMFD.getDelta());
             for (int b = 0; b < numBins; b++) {
                 func.set(b, bins[b]);
             }
             String legend = cat.contains("+") ? cat : cat + " only";
             func.setName(legend);
-            funcs.add(func);
-            chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, COLORS.get(i)));
+            incrMFDs.add(func);
+            incrFuncs.add(func);
+            incrChars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, COLORS.get(i)));
         }
-
-        // Find smallest nonzero y value across all curves
-        double minNonZeroY = Double.MAX_VALUE;
-        for (DiscretizedFunc func : funcs) {
-            for (int b = 0; b < func.size(); b++) {
-                double y = func.getY(b);
-                if (y > 0 && y < minNonZeroY) {
-                    minNonZeroY = y;
-                }
-            }
-        }
-        Range yRange = null;
-        if (minNonZeroY < Double.MAX_VALUE) {
-            // Find max y for upper bound
-            double maxY = 0;
-            for (DiscretizedFunc func : funcs) {
-                for (int b = 0; b < func.size(); b++) {
-                    maxY = Math.max(maxY, func.getY(b));
-                }
-            }
-            yRange = new Range(minNonZeroY / 10.0, maxY * 2.0);
-        }
-
-        PlotSpec spec =
-                new PlotSpec(
-                        funcs,
-                        chars,
-                        "Joint Rupture MFDs",
-                        "Magnitude",
-                        "Incremental Rate (per yr)");
-        spec.setLegendInset(true);
 
         Range xRange =
                 new Range(
                         templateMFD.getMinX() - 0.5 * templateMFD.getDelta(),
                         templateMFD.getMaxX() + 0.5 * templateMFD.getDelta());
 
-        HeadlessGraphPanel gp = PlotUtils.initHeadless(PlotPreferences.getDefaultAppPrefs());
-        gp.setTickLabelFontSize(20);
-        gp.drawGraphPanel(spec, false, true, xRange, yRange);
+        // Write incremental plot
+        String incrPrefix = "joint_rupture_mfds";
+        writeMFDPlot(
+                incrFuncs,
+                incrChars,
+                "Joint Rupture MFDs",
+                "Incremental Rate (per yr)",
+                xRange,
+                resourcesDir,
+                incrPrefix);
 
-        String prefix = "joint_rupture_mfds";
-        PlotUtils.writePlots(resourcesDir, prefix, gp, 1000, 850, true, true, false);
+        // Build cumulative MFD functions
+        List<DiscretizedFunc> cmlFuncs = new ArrayList<>();
+        List<PlotCurveCharacterstics> cmlChars = new ArrayList<>();
+        for (int i = 0; i < incrMFDs.size(); i++) {
+            EvenlyDiscretizedFunc cmlFunc = incrMFDs.get(i).getCumRateDistWithOffset();
+            cmlFunc.setName(incrMFDs.get(i).getName());
+            cmlFuncs.add(cmlFunc);
+            cmlChars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, COLORS.get(i)));
+        }
 
-        // Build output
+        // Write cumulative plot
+        String cmlPrefix = "joint_rupture_mfds_cumulative";
+        writeMFDPlot(
+                cmlFuncs,
+                cmlChars,
+                "Joint Rupture Cumulative MFDs",
+                "Cumulative Rate (per yr)",
+                xRange,
+                resourcesDir,
+                cmlPrefix);
+
+        // Build output with side-by-side table
+        TableBuilder table = MarkdownUtils.tableBuilder();
+        table.addLine("Incremental MFDs", "Cumulative MFDs");
+        table.initNewLine();
+        table.addColumn("![Incremental Plot](" + relPathToResources + "/" + incrPrefix + ".png)");
+        table.addColumn("![Cumulative Plot](" + relPathToResources + "/" + cmlPrefix + ".png)");
+        table.finalizeLine();
+
         List<String> lines = new ArrayList<>();
-        lines.add("![Joint Rupture MFDs](" + relPathToResources + "/" + prefix + ".png)");
+        lines.addAll(table.build());
         lines.add("");
         lines.add("| Category | Total | With Rate > 0 | % With Rate | Rate Sum |");
         lines.add("|----------|------:|--------------:|------------:|---------:|");

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlot.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlot.java
@@ -1,0 +1,191 @@
+package nz.cri.gns.NZSHM22.opensha.inversion.joint.reporting;
+
+import java.awt.Color;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import nz.cri.gns.NZSHM22.opensha.inversion.joint.PartitionPredicate;
+import nz.cri.gns.NZSHM22.opensha.ruptures.FaultSectionProperties;
+import org.jfree.data.Range;
+import org.opensha.commons.data.function.DiscretizedFunc;
+import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
+import org.opensha.commons.gui.plot.*;
+import org.opensha.commons.util.modules.OpenSHA_Module;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.reports.AbstractRupSetPlot;
+import org.opensha.sha.earthquake.faultSysSolution.reports.ReportMetadata;
+import org.opensha.sha.earthquake.faultSysSolution.reports.plots.SolMFDPlot;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+
+/**
+ * Report plot showing MFDs and rate statistics for joint ruptures (spanning both crustal and
+ * subduction partitions) alongside exclusive rupture types.
+ */
+public class JointRuptureRatePlot extends AbstractRupSetPlot {
+
+    /** The five rupture categories: three exclusive, two joint. */
+    protected static final List<String> CATEGORIES =
+            List.of("CRUSTAL", "HIKURANGI", "PUYSEGUR", "CRUSTAL+HIKURANGI", "CRUSTAL+PUYSEGUR");
+
+    /** Colors for each category, in the same order as {@link #CATEGORIES}. */
+    protected static final List<Color> COLORS =
+            List.of(Color.BLUE, Color.RED, Color.GREEN.darker(), Color.MAGENTA, Color.ORANGE);
+
+    /**
+     * Classifies a rupture based on the partitions of its sections.
+     *
+     * @param partitions the set of partitions found in the rupture's sections
+     * @return the category string, or null if the combination is unrecognised
+     */
+    protected static String classify(Set<PartitionPredicate> partitions) {
+        if (partitions.size() == 1) {
+            return partitions.iterator().next().name();
+        }
+        if (partitions.equals(
+                EnumSet.of(PartitionPredicate.CRUSTAL, PartitionPredicate.HIKURANGI))) {
+            return "CRUSTAL+HIKURANGI";
+        }
+        if (partitions.equals(
+                EnumSet.of(PartitionPredicate.CRUSTAL, PartitionPredicate.PUYSEGUR))) {
+            return "CRUSTAL+PUYSEGUR";
+        }
+        return null;
+    }
+
+    /**
+     * Collects the partitions present in a rupture's sections.
+     *
+     * @param rupSet the rupture set
+     * @param rupIndex the rupture index
+     * @return set of partitions found
+     */
+    protected static Set<PartitionPredicate> partitionsForRup(
+            FaultSystemRupSet rupSet, int rupIndex) {
+        Set<PartitionPredicate> partitions = EnumSet.noneOf(PartitionPredicate.class);
+        for (int secIdx : rupSet.getSectionsIndicesForRup(rupIndex)) {
+            PartitionPredicate p =
+                    FaultSectionProperties.getPartition(rupSet.getFaultSectionData(secIdx));
+            if (p != null) {
+                partitions.add(p);
+            }
+        }
+        return partitions;
+    }
+
+    /** Per-category statistics. */
+    protected static class CategoryStats {
+        public int totalCount;
+        public int withRateCount;
+        public double rateSum;
+    }
+
+    @Override
+    public String getName() {
+        return "Joint Rupture Rates";
+    }
+
+    @Override
+    public List<String> plot(
+            FaultSystemRupSet rupSet,
+            FaultSystemSolution sol,
+            ReportMetadata meta,
+            File resourcesDir,
+            String relPathToResources,
+            String topLink)
+            throws IOException {
+
+        if (sol == null) return null;
+
+        IncrementalMagFreqDist templateMFD =
+                SolMFDPlot.initDefaultMFD(rupSet.getMinMag(), rupSet.getMaxMag());
+        int numBins = templateMFD.size();
+
+        // Accumulate rates per category per bin
+        Map<String, double[]> rateBins = new LinkedHashMap<>();
+        Map<String, CategoryStats> stats = new LinkedHashMap<>();
+        for (String cat : CATEGORIES) {
+            rateBins.put(cat, new double[numBins]);
+            stats.put(cat, new CategoryStats());
+        }
+
+        for (int r = 0; r < rupSet.getNumRuptures(); r++) {
+            Set<PartitionPredicate> partitions = partitionsForRup(rupSet, r);
+            String category = classify(partitions);
+            if (category == null) continue;
+
+            CategoryStats cs = stats.get(category);
+            if (cs == null) continue;
+
+            double rate = sol.getRateForRup(r);
+            double mag = rupSet.getMagForRup(r);
+            int bin = templateMFD.getClosestXIndex(mag);
+
+            cs.totalCount++;
+            if (rate > 0) {
+                cs.withRateCount++;
+                cs.rateSum += rate;
+                rateBins.get(category)[bin] += rate;
+            }
+        }
+
+        // Build MFD functions
+        List<DiscretizedFunc> funcs = new ArrayList<>();
+        List<PlotCurveCharacterstics> chars = new ArrayList<>();
+        for (int i = 0; i < CATEGORIES.size(); i++) {
+            String cat = CATEGORIES.get(i);
+            double[] bins = rateBins.get(cat);
+            EvenlyDiscretizedFunc func =
+                    new EvenlyDiscretizedFunc(
+                            templateMFD.getMinX(), numBins, templateMFD.getDelta());
+            for (int b = 0; b < numBins; b++) {
+                func.set(b, bins[b]);
+            }
+            func.setName(cat);
+            funcs.add(func);
+            chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, COLORS.get(i)));
+        }
+
+        PlotSpec spec =
+                new PlotSpec(
+                        funcs,
+                        chars,
+                        "Joint Rupture MFDs",
+                        "Magnitude",
+                        "Incremental Rate (per yr)");
+        spec.setLegendInset(true);
+
+        Range xRange =
+                new Range(
+                        templateMFD.getMinX() - 0.5 * templateMFD.getDelta(),
+                        templateMFD.getMaxX() + 0.5 * templateMFD.getDelta());
+
+        HeadlessGraphPanel gp = PlotUtils.initHeadless(PlotPreferences.getDefaultAppPrefs());
+        gp.setTickLabelFontSize(20);
+        gp.drawGraphPanel(spec, false, true, xRange, null);
+
+        String prefix = "joint_rupture_mfds";
+        PlotUtils.writePlots(resourcesDir, prefix, gp, 1000, 850, true, true, false);
+
+        // Build output
+        List<String> lines = new ArrayList<>();
+        lines.add("![Joint Rupture MFDs](" + relPathToResources + "/" + prefix + ".png)");
+        lines.add("");
+        lines.add("| Category | Total | With Rate > 0 | % With Rate | Rate Sum |");
+        lines.add("|----------|------:|--------------:|------------:|---------:|");
+        for (String cat : CATEGORIES) {
+            CategoryStats cs = stats.get(cat);
+            double pct = cs.totalCount > 0 ? 100.0 * cs.withRateCount / cs.totalCount : 0.0;
+            lines.add(
+                    String.format(
+                            "| %s | %,d | %,d | %.1f%% | %.4e |",
+                            cat, cs.totalCount, cs.withRateCount, pct, cs.rateSum));
+        }
+        return lines;
+    }
+
+    @Override
+    public Collection<Class<? extends OpenSHA_Module>> getRequiredModules() {
+        return null;
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlot.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlot.java
@@ -83,25 +83,28 @@ public class JointRuptureRatePlot extends AbstractRupSetPlot {
     }
 
     /**
-     * Computes a log-scale y-range from the given functions. Returns null if all values are zero.
+     * Computes a log-scale y-range from the given functions, snapping to decade boundaries as in
+     * {@link SolMFDPlot}. Returns null if all values are zero.
      *
      * @param funcs the functions to scan
-     * @return y-range with padding, or null if no positive values
+     * @return y-range on decade boundaries, or null if no positive values
      */
     protected static Range computeLogYRange(List<DiscretizedFunc> funcs) {
-        double minNonZeroY = Double.MAX_VALUE;
-        double maxY = 0;
+        double minY = 1e-6;
+        double maxY = 1e1;
+        boolean hasData = false;
         for (DiscretizedFunc func : funcs) {
             for (int b = 0; b < func.size(); b++) {
                 double y = func.getY(b);
-                if (y > 0) {
-                    if (y < minNonZeroY) minNonZeroY = y;
-                    if (y > maxY) maxY = y;
+                if (y > 1e-10) {
+                    minY = Math.min(minY, Math.pow(10, Math.floor(Math.log10(y) + 0.1)));
+                    maxY = Math.max(maxY, Math.pow(10, Math.ceil(Math.log10(y) - 0.1)));
+                    hasData = true;
                 }
             }
         }
-        if (minNonZeroY == Double.MAX_VALUE) return null;
-        return new Range(minNonZeroY / 10.0, maxY * 2.0);
+        if (!hasData) return null;
+        return new Range(minY, maxY);
     }
 
     /**

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/PartitionSummaryTable.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/PartitionSummaryTable.java
@@ -1,10 +1,15 @@
 package nz.cri.gns.NZSHM22.opensha.inversion.joint.reporting;
 
+import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import nz.cri.gns.NZSHM22.opensha.inversion.joint.PartitionPredicate;
 import nz.cri.gns.NZSHM22.opensha.ruptures.FaultSectionProperties;
+import org.jfree.data.Range;
+import org.opensha.commons.data.function.DiscretizedFunc;
+import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
+import org.opensha.commons.gui.plot.*;
 import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
@@ -92,9 +97,132 @@ public class PartitionSummaryTable extends AbstractRupSetPlot {
                 sectionCounts, exclusiveCounts, sharedCounts, multiPartitionTotal);
     }
 
+    /** Number of bins for the crustal area fraction histogram. */
+    protected static final int NUM_BINS = 20;
+
+    /** Bin width for the crustal area fraction histogram. */
+    protected static final double BIN_WIDTH = 1.0 / NUM_BINS;
+
+    /**
+     * Computes the crustal area fraction for each joint (multi-partition) rupture.
+     *
+     * @param rupSet the rupture set to analyse
+     * @return list of crustal area fractions (each in [0, 1]) for joint ruptures only
+     */
+    protected static List<Double> computeCrustalFractions(FaultSystemRupSet rupSet) {
+        List<Double> fractions = new ArrayList<>();
+        for (int r = 0; r < rupSet.getNumRuptures(); r++) {
+            List<Integer> secIndices = rupSet.getSectionsIndicesForRup(r);
+            Set<PartitionPredicate> partitions = EnumSet.noneOf(PartitionPredicate.class);
+            for (int secIdx : secIndices) {
+                PartitionPredicate p =
+                        FaultSectionProperties.getPartition(rupSet.getFaultSectionData(secIdx));
+                if (p != null) {
+                    partitions.add(p);
+                }
+            }
+            if (partitions.size() <= 1) {
+                continue;
+            }
+            double crustalArea = 0;
+            double totalArea = 0;
+            for (int secIdx : secIndices) {
+                double area = rupSet.getAreaForSection(secIdx);
+                totalArea += area;
+                FaultSection section = rupSet.getFaultSectionData(secIdx);
+                if (FaultSectionProperties.isCrustal(section)) {
+                    crustalArea += area;
+                }
+            }
+            if (totalArea > 0) {
+                fractions.add(crustalArea / totalArea);
+            }
+        }
+        return fractions;
+    }
+
+    /**
+     * Bins crustal area fractions into a histogram function.
+     *
+     * @param fractions list of crustal area fractions
+     * @return histogram function with {@link #NUM_BINS} bins spanning [0, 1]
+     */
+    protected static EvenlyDiscretizedFunc binFractions(List<Double> fractions) {
+        EvenlyDiscretizedFunc func =
+                new EvenlyDiscretizedFunc(BIN_WIDTH / 2.0, NUM_BINS, BIN_WIDTH);
+        for (double f : fractions) {
+            int bin = func.getClosestXIndex(f);
+            func.set(bin, func.getY(bin) + 1);
+        }
+        return func;
+    }
+
+    /**
+     * Creates the histogram plot and writes it to disk.
+     *
+     * @param primaryFunc histogram function for the primary rupture set
+     * @param compFunc histogram function for the comparison rupture set, or null
+     * @param primaryName display name for the primary series
+     * @param compName display name for the comparison series, or null
+     * @param resourcesDir directory to write plot files
+     * @return the file prefix used for the plot
+     * @throws IOException if writing fails
+     */
+    protected static String writeHistogram(
+            EvenlyDiscretizedFunc primaryFunc,
+            EvenlyDiscretizedFunc compFunc,
+            String primaryName,
+            String compName,
+            File resourcesDir)
+            throws IOException {
+        List<DiscretizedFunc> funcs = new ArrayList<>();
+        List<PlotCurveCharacterstics> chars = new ArrayList<>();
+
+        if (compFunc != null) {
+            primaryFunc.setName(primaryName);
+            compFunc.setName(compName);
+            funcs.add(primaryFunc);
+            chars.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 1f, Color.BLUE));
+            funcs.add(compFunc);
+            chars.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 1f, Color.RED.darker()));
+        } else {
+            funcs.add(primaryFunc);
+            chars.add(new PlotCurveCharacterstics(PlotLineType.HISTOGRAM, 1f, Color.BLUE));
+        }
+
+        PlotSpec spec =
+                new PlotSpec(
+                        funcs,
+                        chars,
+                        "Joint Rupture Crustal Area Fraction",
+                        "Crustal Area Fraction",
+                        "Count");
+        if (compFunc != null) {
+            spec.setLegendInset(true);
+        }
+
+        double maxY = 0;
+        for (DiscretizedFunc f : funcs) {
+            for (int i = 0; i < f.size(); i++) {
+                maxY = Math.max(maxY, f.getY(i));
+            }
+        }
+
+        Range xRange = new Range(0, 1);
+        Range yRange = new Range(0, maxY * 1.05);
+
+        HeadlessGraphPanel gp = PlotUtils.initHeadless(PlotPreferences.getDefaultAppPrefs());
+        gp.setTickLabelFontSize(20);
+        gp.drawGraphPanel(spec, false, false, xRange, yRange);
+
+        String prefix = "joint_area_ratio";
+        PlotUtils.writePlots(resourcesDir, prefix, gp, 1000, 850, true, true, false);
+        return prefix;
+    }
+
     @Override
     public String getName() {
-        return "Ruptures Summary";
+        return "Joint Rupture Summary";
     }
 
     @Override
@@ -170,6 +298,34 @@ public class PartitionSummaryTable extends AbstractRupSetPlot {
                     String.format(
                             "| **Total** | **%,d** | **%,d** |",
                             exclTotal, primary.multiPartitionTotal));
+        }
+
+        // Histogram of crustal area fraction for joint ruptures
+        List<Double> primaryFractions = computeCrustalFractions(rupSet);
+        if (!primaryFractions.isEmpty()) {
+            EvenlyDiscretizedFunc primaryFunc = binFractions(primaryFractions);
+            EvenlyDiscretizedFunc compFunc = null;
+            String primaryName = null;
+            String compName = null;
+            if (hasComparison) {
+                List<Double> compFractions = computeCrustalFractions(meta.comparison.rupSet);
+                if (!compFractions.isEmpty()) {
+                    compFunc = binFractions(compFractions);
+                    primaryName = meta.primary.name;
+                    compName = meta.comparison.name;
+                }
+            }
+            String prefix =
+                    writeHistogram(primaryFunc, compFunc, primaryName, compName, resourcesDir);
+            lines.add(
+                    "!["
+                            + "Joint Rupture Crustal Area Fraction"
+                            + "]("
+                            + relPathToResources
+                            + "/"
+                            + prefix
+                            + ".png)");
+            lines.add("");
         }
 
         return lines;

--- a/src/main/java/nz/cri/gns/NZSHM22/util/NZSHM22_ReportPageGen.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/util/NZSHM22_ReportPageGen.java
@@ -13,6 +13,7 @@ import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_LogicTreeBranch;
 import nz.cri.gns.NZSHM22.opensha.inversion.joint.PartitionMfds;
 import nz.cri.gns.NZSHM22.opensha.inversion.joint.PartitionPredicate;
 import nz.cri.gns.NZSHM22.opensha.inversion.joint.ReportFaultSystemRuptSet;
+import nz.cri.gns.NZSHM22.opensha.inversion.joint.reporting.JointRuptureRatePlot;
 import nz.cri.gns.NZSHM22.opensha.inversion.joint.reporting.PartitionPlotWrapper;
 import nz.cri.gns.NZSHM22.opensha.inversion.joint.reporting.PartitionSummaryTable;
 import nz.cri.gns.NZSHM22.opensha.ruptures.CustomFaultModel;
@@ -117,6 +118,8 @@ public class NZSHM22_ReportPageGen {
             }
         }
         possibleRupSetPlots.put("PartitionSummaryTable", new PartitionSummaryTable());
+        possiblePlots.put("JointRuptureRatePlot", new JointRuptureRatePlot());
+        possibleRupSetPlots.put("JointRuptureRatePlot", new JointRuptureRatePlot());
     }
 
     /**

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlotTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlotTest.java
@@ -1,0 +1,169 @@
+package nz.cri.gns.NZSHM22.opensha.inversion.joint.reporting;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import nz.cri.gns.NZSHM22.opensha.inversion.joint.PartitionPredicate;
+import nz.cri.gns.NZSHM22.opensha.ruptures.FaultSectionProperties;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opensha.commons.geo.Location;
+import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.reports.ReportMetadata;
+import org.opensha.sha.faultSurface.FaultTrace;
+import org.opensha.sha.faultSurface.GeoJSONFaultSection;
+
+/** Tests for {@link JointRuptureRatePlot}. */
+public class JointRuptureRatePlotTest {
+
+    @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private GeoJSONFaultSection makeSection(int id, PartitionPredicate partition) {
+        FaultTrace trace = new FaultTrace("trace");
+        trace.add(new Location(-41, 174));
+        trace.add(new Location(-42, 175));
+        FaultSectionPrefData pref = new FaultSectionPrefData();
+        pref.setSectionId(id);
+        pref.setSectionName("Section " + id);
+        pref.setFaultTrace(trace);
+        pref.setAveDip(45);
+        pref.setAveRake(90);
+        pref.setAveUpperDepth(0);
+        pref.setAveLowerDepth(10);
+        pref.setDipDirection((float) trace.getDipDirection());
+        GeoJSONFaultSection section = GeoJSONFaultSection.fromFaultSection(pref);
+        new FaultSectionProperties(section).setPartition(partition);
+        return section;
+    }
+
+    /** Returns null when no solution is provided. */
+    @Test
+    public void testNullSolution() throws Exception {
+        FaultSystemRupSet rupSet = mock(FaultSystemRupSet.class);
+        JointRuptureRatePlot plot = new JointRuptureRatePlot();
+        List<String> result =
+                plot.plot(
+                        rupSet,
+                        (FaultSystemSolution) null,
+                        (ReportMetadata) null,
+                        (File) null,
+                        null,
+                        null);
+        assertNull(result);
+    }
+
+    /** Classifies exclusive ruptures correctly. */
+    @Test
+    public void testClassifyExclusive() {
+        assertEquals(
+                "CRUSTAL", JointRuptureRatePlot.classify(EnumSet.of(PartitionPredicate.CRUSTAL)));
+        assertEquals(
+                "HIKURANGI",
+                JointRuptureRatePlot.classify(EnumSet.of(PartitionPredicate.HIKURANGI)));
+        assertEquals(
+                "PUYSEGUR", JointRuptureRatePlot.classify(EnumSet.of(PartitionPredicate.PUYSEGUR)));
+    }
+
+    /** Classifies joint ruptures correctly. */
+    @Test
+    public void testClassifyJoint() {
+        assertEquals(
+                "CRUSTAL+HIKURANGI",
+                JointRuptureRatePlot.classify(
+                        EnumSet.of(PartitionPredicate.CRUSTAL, PartitionPredicate.HIKURANGI)));
+        assertEquals(
+                "CRUSTAL+PUYSEGUR",
+                JointRuptureRatePlot.classify(
+                        EnumSet.of(PartitionPredicate.CRUSTAL, PartitionPredicate.PUYSEGUR)));
+    }
+
+    /** Returns null for unrecognised partition combinations. */
+    @Test
+    public void testClassifyUnknown() {
+        assertNull(
+                JointRuptureRatePlot.classify(
+                        EnumSet.of(PartitionPredicate.HIKURANGI, PartitionPredicate.PUYSEGUR)));
+    }
+
+    /** Produces markdown output with chart and table for a solution with joint ruptures. */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPlotProducesOutput() throws Exception {
+        GeoJSONFaultSection s0 = makeSection(0, PartitionPredicate.CRUSTAL);
+        GeoJSONFaultSection s1 = makeSection(1, PartitionPredicate.HIKURANGI);
+        GeoJSONFaultSection s2 = makeSection(2, PartitionPredicate.PUYSEGUR);
+
+        List sections = Arrays.asList(s0, s1, s2);
+
+        FaultSystemRupSet rupSet = mock(FaultSystemRupSet.class);
+        when(rupSet.getFaultSectionDataList()).thenReturn(sections);
+        when(rupSet.getNumRuptures()).thenReturn(3);
+        when(rupSet.getMinMag()).thenReturn(6.0);
+        when(rupSet.getMaxMag()).thenReturn(8.0);
+
+        // Rup 0: exclusive CRUSTAL
+        when(rupSet.getSectionsIndicesForRup(0)).thenReturn(Arrays.asList(0));
+        when(rupSet.getFaultSectionData(0)).thenReturn(s0);
+        when(rupSet.getMagForRup(0)).thenReturn(6.5);
+
+        // Rup 1: exclusive HIKURANGI
+        when(rupSet.getSectionsIndicesForRup(1)).thenReturn(Arrays.asList(1));
+        when(rupSet.getFaultSectionData(1)).thenReturn(s1);
+        when(rupSet.getMagForRup(1)).thenReturn(7.0);
+
+        // Rup 2: joint CRUSTAL+HIKURANGI
+        when(rupSet.getSectionsIndicesForRup(2)).thenReturn(Arrays.asList(0, 1));
+        when(rupSet.getMagForRup(2)).thenReturn(7.5);
+
+        FaultSystemSolution sol = mock(FaultSystemSolution.class);
+        when(sol.getRupSet()).thenReturn(rupSet);
+        when(sol.getRateForRup(0)).thenReturn(1e-4);
+        when(sol.getRateForRup(1)).thenReturn(0.0);
+        when(sol.getRateForRup(2)).thenReturn(2e-5);
+
+        File resourcesDir = tempFolder.newFolder("resources");
+
+        JointRuptureRatePlot plot = new JointRuptureRatePlot();
+        List<String> lines =
+                plot.plot(rupSet, sol, (ReportMetadata) null, resourcesDir, "resources", "");
+
+        assertNotNull(lines);
+        assertFalse(lines.isEmpty());
+
+        // Should contain image reference
+        assertTrue(lines.stream().anyMatch(l -> l.contains("joint_rupture_mfds.png")));
+
+        // Should contain table with all 5 categories
+        String allText = String.join("\n", lines);
+        assertTrue(allText.contains("CRUSTAL+HIKURANGI"));
+        assertTrue(allText.contains("CRUSTAL+PUYSEGUR"));
+
+        // CRUSTAL row: 1 total, 1 with rate
+        String crustalRow =
+                lines.stream().filter(l -> l.startsWith("| CRUSTAL |")).findFirst().orElseThrow();
+        assertTrue(crustalRow.contains("| 1 | 1 |"));
+
+        // HIKURANGI row: 1 total, 0 with rate
+        String hikRow =
+                lines.stream().filter(l -> l.startsWith("| HIKURANGI |")).findFirst().orElseThrow();
+        assertTrue(hikRow.contains("| 1 | 0 |"));
+
+        // CRUSTAL+HIKURANGI row: 1 total, 1 with rate
+        String jointRow =
+                lines.stream()
+                        .filter(l -> l.contains("CRUSTAL+HIKURANGI"))
+                        .findFirst()
+                        .orElseThrow();
+        assertTrue(jointRow.contains("| 1 | 1 |"));
+
+        // PNG file should have been written
+        assertTrue(new File(resourcesDir, "joint_rupture_mfds.png").exists());
+    }
+}

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlotTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/JointRuptureRatePlotTest.java
@@ -137,11 +137,12 @@ public class JointRuptureRatePlotTest {
         assertNotNull(lines);
         assertFalse(lines.isEmpty());
 
-        // Should contain image reference
-        assertTrue(lines.stream().anyMatch(l -> l.contains("joint_rupture_mfds.png")));
-
-        // Should contain table with all 5 categories
+        // Should contain side-by-side table with incremental and cumulative image references
         String allText = String.join("\n", lines);
+        assertTrue(allText.contains("joint_rupture_mfds.png"));
+        assertTrue(allText.contains("joint_rupture_mfds_cumulative.png"));
+        assertTrue(allText.contains("Incremental MFDs"));
+        assertTrue(allText.contains("Cumulative MFDs"));
         assertTrue(allText.contains("CRUSTAL+HIKURANGI"));
         assertTrue(allText.contains("CRUSTAL+PUYSEGUR"));
 
@@ -163,7 +164,8 @@ public class JointRuptureRatePlotTest {
                         .orElseThrow();
         assertTrue(jointRow.contains("| 1 | 1 |"));
 
-        // PNG file should have been written
+        // PNG files should have been written
         assertTrue(new File(resourcesDir, "joint_rupture_mfds.png").exists());
+        assertTrue(new File(resourcesDir, "joint_rupture_mfds_cumulative.png").exists());
     }
 }

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/PartitionSummaryTableTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/reporting/PartitionSummaryTableTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import nz.cri.gns.NZSHM22.opensha.inversion.joint.PartitionPredicate;
 import nz.cri.gns.NZSHM22.opensha.ruptures.FaultSectionProperties;
 import org.junit.Test;
+import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
 import org.opensha.commons.geo.Location;
 import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
@@ -268,6 +269,99 @@ public class PartitionSummaryTableTest {
         assertTrue(
                 "Primary 0 excl, comp 1: " + hikurangiRow,
                 hikurangiRow.contains("| 0 | 1 | 0 | 0 |"));
+    }
+
+    /** Tests that computeCrustalFractions returns correct fractions for joint ruptures only. */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testComputeCrustalFractions() {
+        GeoJSONFaultSection s0 = makeSection(0, PartitionPredicate.CRUSTAL);
+        GeoJSONFaultSection s1 = makeSection(1, PartitionPredicate.HIKURANGI);
+        GeoJSONFaultSection s2 = makeSection(2, PartitionPredicate.CRUSTAL);
+
+        List sections = Arrays.asList(s0, s1, s2);
+
+        FaultSystemRupSet rupSet = mock(FaultSystemRupSet.class);
+        when(rupSet.getFaultSectionDataList()).thenReturn(sections);
+        when(rupSet.getNumRuptures()).thenReturn(2);
+
+        // Rup 0: exclusive CRUSTAL — should be skipped
+        when(rupSet.getSectionsIndicesForRup(0)).thenReturn(Arrays.asList(0, 2));
+        when(rupSet.getFaultSectionData(0)).thenReturn(s0);
+        when(rupSet.getFaultSectionData(2)).thenReturn(s2);
+
+        // Rup 1: joint CRUSTAL+HIKURANGI (sections 0, 1)
+        when(rupSet.getSectionsIndicesForRup(1)).thenReturn(Arrays.asList(0, 1));
+        when(rupSet.getFaultSectionData(1)).thenReturn(s1);
+
+        // Section 0 (crustal): area 300, Section 1 (hikurangi): area 700
+        when(rupSet.getAreaForSection(0)).thenReturn(300.0);
+        when(rupSet.getAreaForSection(1)).thenReturn(700.0);
+        when(rupSet.getAreaForSection(2)).thenReturn(500.0);
+
+        List<Double> fractions = PartitionSummaryTable.computeCrustalFractions(rupSet);
+
+        assertEquals("Only joint ruptures should be included", 1, fractions.size());
+        assertEquals(0.3, fractions.get(0), 1e-9);
+    }
+
+    /** Tests that binFractions correctly bins fractions into the histogram. */
+    @Test
+    public void testBinFractions() {
+        List<Double> fractions = Arrays.asList(0.1, 0.12, 0.9, 0.5);
+        EvenlyDiscretizedFunc func = PartitionSummaryTable.binFractions(fractions);
+
+        assertEquals(PartitionSummaryTable.NUM_BINS, func.size());
+
+        // 0.1 and 0.12 should both land in bin centered at 0.125 (bin index 2)
+        assertEquals(2.0, func.getY(2), 1e-9);
+
+        // 0.5 should land in bin centered at 0.525 (bin index 10)
+        assertEquals(1.0, func.getY(10), 1e-9);
+
+        // 0.9 should land in bin centered at 0.925 (bin index 18)
+        assertEquals(1.0, func.getY(18), 1e-9);
+    }
+
+    /** Tests that plot includes histogram image when joint ruptures have nonzero area. */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPlotIncludesHistogram() throws Exception {
+        GeoJSONFaultSection s0 = makeSection(0, PartitionPredicate.CRUSTAL);
+        GeoJSONFaultSection s1 = makeSection(1, PartitionPredicate.HIKURANGI);
+
+        List sections = Arrays.asList(s0, s1);
+
+        FaultSystemRupSet rupSet = mock(FaultSystemRupSet.class);
+        when(rupSet.getFaultSectionDataList()).thenReturn(sections);
+        when(rupSet.getNumRuptures()).thenReturn(1);
+
+        // One joint rupture
+        when(rupSet.getSectionsIndicesForRup(0)).thenReturn(Arrays.asList(0, 1));
+        when(rupSet.getFaultSectionData(0)).thenReturn(s0);
+        when(rupSet.getFaultSectionData(1)).thenReturn(s1);
+        when(rupSet.getAreaForSection(0)).thenReturn(400.0);
+        when(rupSet.getAreaForSection(1)).thenReturn(600.0);
+
+        File tempDir =
+                new File(System.getProperty("java.io.tmpdir"), "pst_test_" + System.nanoTime());
+        tempDir.mkdirs();
+
+        try {
+            PartitionSummaryTable table = new PartitionSummaryTable();
+            List<String> lines =
+                    table.plot(rupSet, null, (ReportMetadata) null, tempDir, "resources", null);
+
+            String allText = String.join("\n", lines);
+            assertTrue("Should contain table", allText.contains("Partition"));
+            assertTrue("Should contain histogram image", allText.contains("joint_area_ratio.png"));
+        } finally {
+            // Clean up temp files
+            for (File f : tempDir.listFiles()) {
+                f.delete();
+            }
+            tempDir.delete();
+        }
     }
 
     /**


### PR DESCRIPTION
closes #479 

chart

<img width="1389" height="643" alt="image" src="https://github.com/user-attachments/assets/7dc6cb28-4519-4976-93fb-9a8e6a5c5a2f" />

table

<img width="639" height="239" alt="image" src="https://github.com/user-attachments/assets/2451038f-7c81-4591-8b90-c242b39389d4" />


Also edited `PartitionSummaryTable` to give insight into joint rupture composition:

<img width="964" height="839" alt="image" src="https://github.com/user-attachments/assets/802c1d0a-6d46-48cf-96f3-7a375b0c83be" />

A histogram like this is in OpenSHA's `RupHistogramPlots`, but it's faulty and will need to be deleted.
