### PR TITLE
[481] Joint Rupture Set Pipeline

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/InversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/joint/InversionRunner.java
@@ -57,7 +57,7 @@ public class InversionRunner {
 
         // InversionRunner runner = new InversionRunner("crustal-reproducible.json");
         FaultSystemSolution solution = runner.run();
-        solution.write(new File("/work/inversionSolution.zip"));
+        solution.write(new File("/tmp/inversionSolution.zip"));
 
         System.out.println(TraceTool.getTraces());
     }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Builder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Builder.java
@@ -10,6 +10,7 @@ import org.dom4j.DocumentException;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.multiRupture.RuptureMerger;
 
+/** Joint Rupture Builder */
 public class Builder {
 
     public static File makeTempFile(FaultSystemRupSet rupSet) throws IOException {
@@ -18,6 +19,17 @@ public class Builder {
         return tempFile;
     }
 
+    /**
+     * Takes a list of NZSHM22-style rupture sets and creates a joint rupture set. - backfills
+     * properties if input sets are old - accumulates the sets into a single rupture set - applies
+     * thinning (i.e. creates a thinning file for RuptureMerger) - calls RuptureMerger to create a
+     * joint rupture set
+     *
+     * @param ruptureSets a list of rupture sets
+     * @param backfill whether to backfill properties on the input rupture sets
+     * @throws IOException
+     * @throws DocumentException
+     */
     public static void buildJointRuptures(List<String> ruptureSets, boolean backfill)
             throws IOException, DocumentException {
         List<FaultSystemRupSet> rupSets = new ArrayList<>();

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Builder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Builder.java
@@ -1,0 +1,48 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
+
+import nz.cri.gns.NZSHM22.opensha.scripts.RupSetPropertyBackfill;
+import org.dom4j.DocumentException;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.multiRupture.RuptureMerger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Builder {
+
+    public static File makeTempFile(FaultSystemRupSet rupSet) throws IOException {
+        File tempFile = Files.createTempFile("rupset", ".zip").toFile();
+        rupSet.write(tempFile);
+        return tempFile;
+    }
+
+    public static void buildJointRuptures(List<String> ruptureSets, boolean backfill) throws IOException, DocumentException {
+        List<FaultSystemRupSet> rupSets = new ArrayList<>();
+        for(String fileName: ruptureSets){
+            if(backfill){
+                rupSets.add(RupSetPropertyBackfill.backfill(fileName));
+            } else{
+                rupSets.add(FaultSystemRupSet.load(new File(fileName)));
+            }
+        }
+
+        FaultSystemRupSet accumulated = new RuptureAccumulator().addRupSets(rupSets).build();
+
+        File accumulatedFile = makeTempFile(accumulated);
+
+        Thinning.Config thinningConfig = new Thinning.Config();
+        thinningConfig.ruptureSetFileName = accumulatedFile.getAbsolutePath();
+        thinningConfig.outputFileName = Files.createTempFile("thinning", ".csv").toString();
+
+        Thinning.apply(thinningConfig);
+
+        RuptureMerger.Config ruptureMergerConfig = new RuptureMerger.Config();
+        ruptureMergerConfig.ruptureSet = new File(thinningConfig.ruptureSetFileName);
+        ruptureMergerConfig.filterFile = new File(thinningConfig.outputFileName);
+        RuptureMerger.merge(ruptureMergerConfig);
+
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Builder.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Builder.java
@@ -1,15 +1,14 @@
 package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
-import nz.cri.gns.NZSHM22.opensha.scripts.RupSetPropertyBackfill;
-import org.dom4j.DocumentException;
-import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.multiRupture.RuptureMerger;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import nz.cri.gns.NZSHM22.opensha.scripts.RupSetPropertyBackfill;
+import org.dom4j.DocumentException;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.multiRupture.RuptureMerger;
 
 public class Builder {
 
@@ -19,12 +18,13 @@ public class Builder {
         return tempFile;
     }
 
-    public static void buildJointRuptures(List<String> ruptureSets, boolean backfill) throws IOException, DocumentException {
+    public static void buildJointRuptures(List<String> ruptureSets, boolean backfill)
+            throws IOException, DocumentException {
         List<FaultSystemRupSet> rupSets = new ArrayList<>();
-        for(String fileName: ruptureSets){
-            if(backfill){
+        for (String fileName : ruptureSets) {
+            if (backfill) {
                 rupSets.add(RupSetPropertyBackfill.backfill(fileName));
-            } else{
+            } else {
                 rupSets.add(FaultSystemRupSet.load(new File(fileName)));
             }
         }
@@ -43,6 +43,5 @@ public class Builder {
         ruptureMergerConfig.ruptureSet = new File(thinningConfig.ruptureSetFileName);
         ruptureMergerConfig.filterFile = new File(thinningConfig.outputFileName);
         RuptureMerger.merge(ruptureMergerConfig);
-
     }
 }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/RuptureAccumulator.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/RuptureAccumulator.java
@@ -139,6 +139,11 @@ public class RuptureAccumulator {
         return this;
     }
 
+    public RuptureAccumulator addRupSets(Collection<FaultSystemRupSet> rupSets){
+        rupSets.forEach(this::add);
+        return this;
+    }
+
     static double[] toDoubleArray(List<Double> values) {
         double[] result = new double[values.size()];
         for (int i = 0; i < result.length; i++) {

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/RuptureAccumulator.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/RuptureAccumulator.java
@@ -139,7 +139,7 @@ public class RuptureAccumulator {
         return this;
     }
 
-    public RuptureAccumulator addRupSets(Collection<FaultSystemRupSet> rupSets){
+    public RuptureAccumulator addRupSets(Collection<FaultSystemRupSet> rupSets) {
         rupSets.forEach(this::add);
         return this;
     }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Thinning.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Thinning.java
@@ -1,16 +1,15 @@
 package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
-import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 
 public class Thinning {
 
-    public static class Config{
+    public static class Config {
         public String ruptureSetFileName;
         public String outputFileName;
         public boolean hikurangiPosition = true;
@@ -28,10 +27,10 @@ public class Thinning {
 
         ThinningSubduction hikurangiThinning =
                 new ThinningSubduction(rupSet, s -> s.startsWith("Hikurangi"));
-        if(config.hikurangiPosition) {
+        if (config.hikurangiPosition) {
             hikurangiThinning.filterByPosition();
         }
-        if(config.hikurangiSize != null) {
+        if (config.hikurangiSize != null) {
             hikurangiThinning.filterBySize(config.hikurangiSize);
         }
 
@@ -39,10 +38,10 @@ public class Thinning {
 
         ThinningSubduction puysegurThinning =
                 new ThinningSubduction(rupSet, s -> s.startsWith("Puysegur"));
-        if(config.puysegurPosition) {
+        if (config.puysegurPosition) {
             puysegurThinning.filterByPosition();
         }
-        if(config.puysegurSize!=null) {
+        if (config.puysegurSize != null) {
             puysegurThinning.filterBySize(config.puysegurSize);
         }
 

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Thinning.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Thinning.java
@@ -1,0 +1,73 @@
+package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
+
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+public class Thinning {
+
+    public static class Config{
+        public String ruptureSetFileName;
+        public String outputFileName;
+        public boolean hikurangiPosition = true;
+        public Double hikurangiSize = 0.1;
+        public boolean puysegurPosition = true;
+        public Double puysegurSize = 0.1;
+    }
+
+    public static void apply(Config config) throws IOException {
+        FaultSystemRupSet rupSet = FaultSystemRupSet.load(new File(config.ruptureSetFileName));
+
+        List<Integer> crustalIds = ThinningCrustal.filterCrustal(rupSet);
+
+        System.out.println("crustal after thinning " + crustalIds.size());
+
+        ThinningSubduction hikurangiThinning =
+                new ThinningSubduction(rupSet, s -> s.startsWith("Hikurangi"));
+        if(config.hikurangiPosition) {
+            hikurangiThinning.filterByPosition();
+        }
+        if(config.hikurangiSize != null) {
+            hikurangiThinning.filterBySize(config.hikurangiSize);
+        }
+
+        System.out.println("hikurangi after thinning " + hikurangiThinning.getRuptures().size());
+
+        ThinningSubduction puysegurThinning =
+                new ThinningSubduction(rupSet, s -> s.startsWith("Puysegur"));
+        if(config.puysegurPosition) {
+            puysegurThinning.filterByPosition();
+        }
+        if(config.puysegurSize!=null) {
+            puysegurThinning.filterBySize(config.puysegurSize);
+        }
+
+        System.out.println("puysegur after thinning " + puysegurThinning.getRuptures().size());
+
+        BufferedWriter writer = new BufferedWriter(new FileWriter(config.outputFileName));
+        for (Integer r : crustalIds) {
+            writer.write("" + r);
+            writer.newLine();
+        }
+        for (Integer r : hikurangiThinning.getIds()) {
+            writer.write("" + r);
+            writer.newLine();
+        }
+        for (Integer r : puysegurThinning.getIds()) {
+            writer.write("" + r);
+            writer.newLine();
+        }
+        writer.close();
+    }
+
+    public static void main(String[] args) throws IOException {
+        Config config = new Config();
+        config.ruptureSetFileName = "C:\\Users\\volkertj\\Code\\ruptureSets\\nzshm22_merged.zip";
+        config.outputFileName = "/tmp/filteredRuptures.txt";
+        Thinning.apply(config);
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Thinning.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/Thinning.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.List;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 
+/** Orchestrates thinning of crustal and subduction rupture sets as inputs for RuptureMerger */
 public class Thinning {
 
     public static class Config {

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/ThinningSubduction.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/ThinningSubduction.java
@@ -1,10 +1,6 @@
 package nz.cri.gns.NZSHM22.opensha.ruptures.experimental;
 
 import com.google.common.base.Preconditions;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -133,5 +129,4 @@ public class ThinningSubduction {
             return ruptureIndices.get(rupture);
         }
     }
-
 }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/ThinningSubduction.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/experimental/ThinningSubduction.java
@@ -134,40 +134,4 @@ public class ThinningSubduction {
         }
     }
 
-    public static void main(String[] args) throws IOException {
-        FaultSystemRupSet combined =
-                FaultSystemRupSet.load(
-                        new File("C:\\Users\\volkertj\\Code\\ruptureSets\\nzshm22_merged.zip"));
-
-        List<Integer> crustalIds = ThinningCrustal.filterCrustal(combined);
-
-        ThinningSubduction hikurangiThinning =
-                new ThinningSubduction(combined, s -> s.startsWith("Hikurangi"));
-        hikurangiThinning.filterByPosition();
-        hikurangiThinning.filterBySize(0.1);
-
-        System.out.println("hikurangi after thinning " + hikurangiThinning.getRuptures().size());
-
-        ThinningSubduction puysegurThinning =
-                new ThinningSubduction(combined, s -> s.startsWith("Puysegur"));
-        puysegurThinning.filterByPosition();
-        puysegurThinning.filterBySize(0.1);
-
-        System.out.println("puysegur after thinning " + puysegurThinning.getRuptures().size());
-
-        BufferedWriter writer = new BufferedWriter(new FileWriter("/tmp/filteredRuptures.txt"));
-        for (Integer r : crustalIds) {
-            writer.write("" + r);
-            writer.newLine();
-        }
-        for (Integer r : hikurangiThinning.getIds()) {
-            writer.write("" + r);
-            writer.newLine();
-        }
-        for (Integer r : puysegurThinning.getIds()) {
-            writer.write("" + r);
-            writer.newLine();
-        }
-        writer.close();
-    }
 }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/scripts/RupSetPropertyBackfill.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/scripts/RupSetPropertyBackfill.java
@@ -39,7 +39,8 @@ public class RupSetPropertyBackfill {
         return backfill(rupSet);
     }
 
-    public static FaultSystemRupSet backfill(FaultSystemRupSet rupSet) throws IOException, DocumentException{
+    public static FaultSystemRupSet backfill(FaultSystemRupSet rupSet)
+            throws IOException, DocumentException {
 
         // Try to get fault model from logic tree branch for crustal lookups
         NZSHM22_LogicTreeBranch branch = rupSet.getModule(NZSHM22_LogicTreeBranch.class);

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/scripts/RupSetPropertyBackfill.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/scripts/RupSetPropertyBackfill.java
@@ -35,8 +35,11 @@ public class RupSetPropertyBackfill {
     @SuppressWarnings("unchecked")
     public static FaultSystemRupSet backfill(String archiveFileName)
             throws IOException, DocumentException {
-
         FaultSystemRupSet rupSet = FaultSystemRupSet.load(new File(archiveFileName));
+        return backfill(rupSet);
+    }
+
+    public static FaultSystemRupSet backfill(FaultSystemRupSet rupSet) throws IOException, DocumentException{
 
         // Try to get fault model from logic tree branch for crustal lookups
         NZSHM22_LogicTreeBranch branch = rupSet.getModule(NZSHM22_LogicTreeBranch.class);

--- a/src/main/resources/parameters/NZSHM_config-parallel.jsonc
+++ b/src/main/resources/parameters/NZSHM_config-parallel.jsonc
@@ -1,11 +1,11 @@
 {
-  "ruptureSetPath": "C:\\runs\\NZSHM22_rupsets\\nzshm22_merged.zip",
+  "ruptureSetPath": "C:\\runs\\run_4\\mergedRupset_15km_cffPatch2km_cff0SelfStiffness.zip",
  // "ruptureSetPath": "C:\\runs\\run_1\\rupset\\mergedRupset_15km_cffPatch2km_cff0SelfStiffness.zip",
  // "ruptureSetPath": "C:\\Users\\volkertj\\Code\\ruptureSets\\mergedRupset_5km_cffPatch2km_cff0SelfStiffness.zipprops2.zip",
  //  "ruptureSetPath": "C:\\Users\\volkertj\\Code\\ruptureSets\\NZSHM22_RuptureSet-UnVwdHVyZUdlbmVyYXRpb25UYXNrOjEwMDAzOA==.zipprops2.zip",
   //"ruptureSetPath": "C:\\Users\\volkertj\\Code\\ruptureSets\\RupSet_Sub_FM(SBD_0_3_HKR_LR_30)_mnSbS(2)_mnSSPP(2)_mxSSL(0.5)_ddAsRa(2.0,5.0,5)_ddMnFl(0.1)_ddPsCo(0.0)_ddSzCo(0.0)_thFc(0.0).zipprops2.zip",
   "annealing": {
-    "inversionSecs": 60,
+    "inversionSecs": 3600,
     "selectionInterval": 10,
     "inversionAveragingIntervalSecs": 10,
     "inversionNumSolutionAverages": 4,


### PR DESCRIPTION
closes #481

Provides users with a simple pipeline to create joint rupture sets from NZSHM22-style rupture sets. This is meant for experimenting with thinning and joint rupture creation.

relies on https://github.com/opensha/opensha/pull/225 (merged now)