### PR TITLE
Fix DomainFilter IllegalArgumentException in rupture set building

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/FaultFilter.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/ruptures/FaultFilter.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import nz.cri.gns.NZSHM22.opensha.faults.FaultSectionList;
+import nz.cri.gns.NZSHM22.opensha.faults.NZFaultSection;
 import org.opensha.commons.geo.Location;
 import org.opensha.commons.geo.LocationList;
 import org.opensha.commons.geo.Region;
@@ -98,7 +99,7 @@ public interface FaultFilter {
 
         @Override
         public boolean keep(FaultSection section) {
-            return !domains.contains(FaultSectionProperties.getDomain(section));
+            return !domains.contains(((NZFaultSection) section).getDomainNo());
         }
 
         @Override


### PR DESCRIPTION
## Problem

Building a rupture set with the domain filter (`setDomainFilter`) threw:

```
java.lang.IllegalArgumentException
  at FaultSectionProperties.<init>(FaultSectionProperties.java:38)   // checkArgument(section instanceof GeoJSONFaultSection)
  at FaultSectionProperties.getDomain(FaultSectionProperties.java:158)
  at FaultFilter$DomainFilter.keep(FaultFilter.java:101)
  ...
  at NZSHM22_AbstractRuptureSetBuilder.loadFaults(...)
```

## Root cause

`FaultFilter`s run inside `loadFaults()` **before** subsections are created and converted to `GeoJSONFaultSection`. At that point the sections are raw `NZFaultSection` objects (which extend `FaultSectionPrefData`, not `GeoJSONFaultSection`).

`DomainFilter.keep()` called `FaultSectionProperties.getDomain(section)`, whose constructor asserts the section is a `GeoJSONFaultSection` — hence the exception. The domain value at filter time lives in `NZFaultSection.getDomainNo()`; the GeoJSON `Domain` property is only populated later.

## Fix

`DomainFilter.keep()` now reads the domain directly via `((NZFaultSection) section).getDomainNo()`, consistent with the other filters and with the existing `NZFaultSection` casts downstream in `loadFaults()`.

## Verification

- `./gradlew compileJava` passes.
- Rerun a Coulomb build with `setDomainFilter(...)` to confirm it filters (log: `Fault model filtered to N after applying domain filter ...`) instead of throwing.

https://claude.ai/code/session_01KypBZakZvWK4LW9Z1WcPcw