### PR TITLE
fix: correct seMatrixDumpPath to setMatrixDumpPath method name typo

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
@@ -118,7 +118,7 @@ public abstract class NZSHM22_AbstractInversionRunner {
      * @param path a folder in which to dump A and d
      * @return this runner
      */
-    public NZSHM22_AbstractInversionRunner seMatrixDumpPath(String path) {
+    public NZSHM22_AbstractInversionRunner setMatrixDumpPath(String path) {
         File file = new File(path);
         Preconditions.checkArgument(file.exists(), "Matrix dump path must exist.");
         Preconditions.checkArgument(file.isDirectory(), "Matrix dump path must be directory.");


### PR DESCRIPTION
## Summary

Corrects method name typo in NZSHM22_AbstractInversionRunner.java.

**Before:** `seMatrixDumpPath` (missing 't')  
**After:** `setMatrixDumpPath`

## Fixes

Fixes issue #496

## Testing

- [x] Code compiles (surgical 1-line rename, no logic change)