### PR TITLE
Feature/495 preserve inputs

### DIFF
--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
@@ -988,18 +988,4 @@ public abstract class NZSHM22_AbstractInversionRunner {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         return gson.toJson(this);
     }
-
-    // this needs to go into the subclasses
-    public static NZSHM22_AbstractInversionRunner fromJson(String json) {
-        // Set to lenient to allow comments.
-        // It's a bit too lenient for us, but at least comments are parsed correctly out of the box.
-        Gson gson = new GsonBuilder().setLenient().create();
-        return gson.fromJson(json, NZSHM22_AbstractInversionRunner.class);
-    }
-
-    public void writeToStream(OutputStream out) throws IOException {
-        Writer writer = new OutputStreamWriter(out);
-        writer.write(toJson());
-        writer.flush();
-    }
 }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
@@ -1,12 +1,14 @@
 package nz.cri.gns.NZSHM22.opensha.inversion;
 
 import com.google.common.base.Preconditions;
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
+
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.*;
 import nz.cri.gns.NZSHM22.opensha.reports.TabularMfds;
 import nz.cri.gns.NZSHM22.opensha.ruptures.NZSHM22_AbstractRuptureSetBuilder;
@@ -61,19 +63,19 @@ public abstract class NZSHM22_AbstractInversionRunner {
 
     private NZSHM22_SpatialSeisPDF spatialSeisPDF = null;
 
-    protected File rupSetFile;
-    protected ArchiveInput rupSetInput;
-    protected NZSHM22_InversionFaultSystemRuptSet rupSet = null;
+    protected String rupSetFile;
+    protected transient ArchiveInput rupSetInput;
+    protected transient NZSHM22_InversionFaultSystemRuptSet rupSet = null;
     protected NZSHM22_DeformationModel deformationModel = null;
-    protected List<InversionConstraint> constraints = new ArrayList<>();
-    private EnergyChangeCompletionCriteria energyChangeCompletionCriteria = null;
-    private IterationCompletionCriteria iterationCompletionCriteria = null;
+    protected transient List<InversionConstraint> constraints = new ArrayList<>();
+    private transient EnergyChangeCompletionCriteria energyChangeCompletionCriteria = null;
+    private transient IterationCompletionCriteria iterationCompletionCriteria = null;
 
-    private ThreadedSimulatedAnnealing tsa;
+    private transient ThreadedSimulatedAnnealing tsa;
     private double[] initialState;
-    private FaultSystemSolution solution;
+    private transient FaultSystemSolution solution;
 
-    private InversionInputGenerator inversionInputGenerator;
+    private transient InversionInputGenerator inversionInputGenerator;
 
     protected AbstractInversionConfiguration.NZSlipRateConstraintWeightingType
             slipRateWeightingType;
@@ -108,7 +110,7 @@ public abstract class NZSHM22_AbstractInversionRunner {
     protected double bufferSize = 12;
     protected double minBufferSize = 0;
 
-    protected Path matrixDumpPath;
+    protected transient Path matrixDumpPath;
 
     /**
      * Sets the base path for dumping the A matrix and d vector to file. A and d will be written
@@ -438,7 +440,7 @@ public abstract class NZSHM22_AbstractInversionRunner {
     }
 
     public NZSHM22_AbstractInversionRunner setRuptureSetFile(String ruptureSetFileName) {
-        this.rupSetFile = new File(ruptureSetFileName);
+        this.rupSetFile = ruptureSetFileName;
         return this;
     }
 
@@ -449,7 +451,7 @@ public abstract class NZSHM22_AbstractInversionRunner {
      * @return this builder
      */
     public NZSHM22_AbstractInversionRunner setRuptureSetFile(File ruptureSetFile) {
-        this.rupSetFile = ruptureSetFile;
+        this.rupSetFile = ruptureSetFile.getAbsolutePath();
         return this;
     }
 
@@ -463,7 +465,7 @@ public abstract class NZSHM22_AbstractInversionRunner {
             return rupSetInput;
         }
         if (rupSetFile != null) {
-            return new ArchiveInput.ZipFileInput(rupSetFile);
+            return new ArchiveInput.ZipFileInput(new File(rupSetFile));
         }
         throw new IllegalStateException("no rupture set specified");
     }
@@ -981,5 +983,26 @@ public abstract class NZSHM22_AbstractInversionRunner {
 
     public List<List<String>> getTabularSolutionMfdsV2() {
         return TabularMfds.getTabularSolutionMfdsV2(solution);
+    }
+
+
+    public String toJson() {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(this);
+    }
+
+    // this needs to go into the subclasses
+    public static NZSHM22_AbstractInversionRunner fromJson(String json) {
+        // Set to lenient to allow comments.
+        // It's a bit too lenient for us, but at least comments are parsed correctly out of the box.
+        Gson gson = new GsonBuilder().setLenient().create();
+        return gson.fromJson(json, NZSHM22_AbstractInversionRunner.class);
+    }
+
+
+    public void writeToStream(OutputStream out) throws IOException {
+        Writer writer = new OutputStreamWriter(out);
+        writer.write(toJson());
+        writer.flush();
     }
 }

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_AbstractInversionRunner.java
@@ -1,14 +1,12 @@
 package nz.cri.gns.NZSHM22.opensha.inversion;
 
 import com.google.common.base.Preconditions;
-
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.*;
 import nz.cri.gns.NZSHM22.opensha.reports.TabularMfds;
 import nz.cri.gns.NZSHM22.opensha.ruptures.NZSHM22_AbstractRuptureSetBuilder;
@@ -970,6 +968,7 @@ public abstract class NZSHM22_AbstractInversionRunner {
         solution = new FaultSystemSolution(rupSet, solution_adjusted);
         solution.addModule(progress.getProgress());
         solution.addModule(NZSHM22_AbstractRuptureSetBuilder.createBuildInfo());
+        solution.addModule(new NZSHM22_InversionRunnerModule(this));
         if (tsa instanceof ReweightEvenFitSimulatedAnnealing) {
             solution.addModule(((ReweightEvenFitSimulatedAnnealing) tsa).getMisfitProgress());
         }
@@ -985,7 +984,6 @@ public abstract class NZSHM22_AbstractInversionRunner {
         return TabularMfds.getTabularSolutionMfdsV2(solution);
     }
 
-
     public String toJson() {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         return gson.toJson(this);
@@ -998,7 +996,6 @@ public abstract class NZSHM22_AbstractInversionRunner {
         Gson gson = new GsonBuilder().setLenient().create();
         return gson.fromJson(json, NZSHM22_AbstractInversionRunner.class);
     }
-
 
     public void writeToStream(OutputStream out) throws IOException {
         Writer writer = new OutputStreamWriter(out);

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunner.java
@@ -1,14 +1,13 @@
 package nz.cri.gns.NZSHM22.opensha.inversion;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import nz.cri.gns.NZSHM22.opensha.data.region.NewZealandRegions;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.*;
 import nz.cri.gns.NZSHM22.opensha.polygonise.NZSHM22_PolygonisedDistributedModelBuilder;

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunner.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import nz.cri.gns.NZSHM22.opensha.data.region.NewZealandRegions;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.*;
 import nz.cri.gns.NZSHM22.opensha.polygonise.NZSHM22_PolygonisedDistributedModelBuilder;
@@ -44,11 +47,18 @@ public class NZSHM22_CrustalInversionRunner extends NZSHM22_AbstractInversionRun
     private boolean enableTvzMFDs = false;
     private boolean enableMinMaxSampler = false;
 
-    private NZSHM22_PolygonisedDistributedModelBuilder polygoniser = null;
+    private transient NZSHM22_PolygonisedDistributedModelBuilder polygoniser = null;
 
     /** Creates a new NZSHM22_InversionRunner with defaults. */
     public NZSHM22_CrustalInversionRunner() {
         super();
+    }
+
+    public static NZSHM22_CrustalInversionRunner fromJson(String json) {
+        // Set to lenient to allow comments.
+        // It's a bit too lenient for us, but at least comments are parsed correctly out of the box.
+        Gson gson = new GsonBuilder().setLenient().create();
+        return gson.fromJson(json, NZSHM22_CrustalInversionRunner.class);
     }
 
     /**

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionRunnerModule.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionRunnerModule.java
@@ -1,0 +1,78 @@
+package nz.cri.gns.NZSHM22.opensha.inversion;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import org.opensha.commons.util.modules.helpers.FileBackedModule;
+
+/**
+ * Persists the {@link NZSHM22_AbstractInversionRunner} that produced a solution alongside it, so
+ * that the exact runner configuration can be reconstituted later.
+ */
+public class NZSHM22_InversionRunnerModule implements FileBackedModule {
+
+    private NZSHM22_AbstractInversionRunner runner;
+
+    public NZSHM22_InversionRunnerModule() {}
+
+    public NZSHM22_InversionRunnerModule(NZSHM22_AbstractInversionRunner runner) {
+        this.runner = runner;
+    }
+
+    public NZSHM22_AbstractInversionRunner getRunner() {
+        return runner;
+    }
+
+    protected String toJson() {
+        JsonObject envelope = new JsonObject();
+        envelope.addProperty("class", runner.getClass().getName());
+        envelope.add("runner", JsonParser.parseString(runner.toJson()));
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(envelope);
+    }
+
+    protected static NZSHM22_AbstractInversionRunner fromJson(String json) {
+        try {
+            JsonObject envelope = JsonParser.parseString(json).getAsJsonObject();
+            String className = envelope.get("class").getAsString();
+            String runnerJson = envelope.get("runner").toString();
+            Class<?> runnerClass = Class.forName(className);
+            Method fromJson = runnerClass.getMethod("fromJson", String.class);
+            return (NZSHM22_AbstractInversionRunner) fromJson.invoke(null, runnerJson);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Unable to reconstitute inversion runner from JSON", e);
+        }
+    }
+
+    @Override
+    public String getFileName() {
+        return "NZSHM22_runner.json";
+    }
+
+    @Override
+    public void writeToStream(OutputStream out) throws IOException {
+        Writer writer = new OutputStreamWriter(out);
+        writer.write(toJson());
+        writer.flush();
+    }
+
+    @Override
+    public void initFromStream(BufferedInputStream in) throws IOException {
+        byte[] bytes = in.readAllBytes();
+        String data = new String(bytes, StandardCharsets.UTF_8);
+        runner = fromJson(data);
+    }
+
+    @Override
+    public String getName() {
+        return "NZSHM22 Inversion Runner Config";
+    }
+}

--- a/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_SubductionInversionRunner.java
+++ b/src/main/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_SubductionInversionRunner.java
@@ -1,6 +1,8 @@
 package nz.cri.gns.NZSHM22.opensha.inversion;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_LogicTreeBranch;
 import nz.cri.gns.NZSHM22.opensha.util.ParameterRunner;
@@ -16,6 +18,13 @@ public class NZSHM22_SubductionInversionRunner extends NZSHM22_AbstractInversion
     /** Creates a new NZSHM22_InversionRunner with defaults. */
     public NZSHM22_SubductionInversionRunner() {
         super();
+    }
+
+    public static NZSHM22_SubductionInversionRunner fromJson(String json) {
+        // Set to lenient to allow comments.
+        // It's a bit too lenient for us, but at least comments are parsed correctly out of the box.
+        Gson gson = new GsonBuilder().setLenient().create();
+        return gson.fromJson(json, NZSHM22_SubductionInversionRunner.class);
     }
 
     /**

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunnerTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_CrustalInversionRunnerTest.java
@@ -79,6 +79,20 @@ public class NZSHM22_CrustalInversionRunnerTest {
         }
     }
 
+    @Test
+    public void testRunnerModuleAttachedToSolution() throws DocumentException, IOException {
+        NZSHM22_CrustalInversionRunner runner = makeRunner();
+
+        FaultSystemSolution solution = runner.runInversion();
+        String expectedJson = runner.toJson();
+
+        NZSHM22_InversionRunnerModule module =
+                solution.getModule(NZSHM22_InversionRunnerModule.class);
+        assertNotNull(module);
+        assertTrue(module.getRunner() instanceof NZSHM22_CrustalInversionRunner);
+        assertEquals(expectedJson, module.getRunner().toJson());
+    }
+
     @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionRunnerModuleTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_InversionRunnerModuleTest.java
@@ -1,0 +1,40 @@
+package nz.cri.gns.NZSHM22.opensha.inversion;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import nz.cri.gns.NZSHM22.opensha.util.ParameterRunner;
+import nz.cri.gns.NZSHM22.opensha.util.Parameters;
+import nz.cri.gns.NZSHM22.opensha.util.TestHelpers;
+import org.dom4j.DocumentException;
+import org.junit.Test;
+
+public class NZSHM22_InversionRunnerModuleTest {
+
+    @Test
+    public void roundTripsCrustalRunner() throws DocumentException, IOException {
+        NZSHM22_CrustalInversionRunner runner = NZSHM22_CrustalInversionRunnerTest.makeRunner();
+
+        NZSHM22_InversionRunnerModule module =
+                (NZSHM22_InversionRunnerModule)
+                        TestHelpers.serialiseDeserialise(new NZSHM22_InversionRunnerModule(runner));
+
+        assertTrue(module.getRunner() instanceof NZSHM22_CrustalInversionRunner);
+        assertEquals(runner.toJson(), module.getRunner().toJson());
+    }
+
+    @Test
+    public void roundTripsSubductionRunner() throws IOException {
+        ParameterRunner parameterRunner =
+                new ParameterRunner(Parameters.NZSHM22.INVERSION_HIKURANGI);
+        NZSHM22_SubductionInversionRunner runner = new NZSHM22_SubductionInversionRunner();
+        parameterRunner.setUpSubductionInversionRunner(runner);
+
+        NZSHM22_InversionRunnerModule module =
+                (NZSHM22_InversionRunnerModule)
+                        TestHelpers.serialiseDeserialise(new NZSHM22_InversionRunnerModule(runner));
+
+        assertTrue(module.getRunner() instanceof NZSHM22_SubductionInversionRunner);
+        assertEquals(runner.toJson(), module.getRunner().toJson());
+    }
+}

--- a/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_SubductionInversionRunnerTest.java
+++ b/src/test/java/nz/cri/gns/NZSHM22/opensha/inversion/NZSHM22_SubductionInversionRunnerTest.java
@@ -1,0 +1,69 @@
+package nz.cri.gns.NZSHM22.opensha.inversion;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.List;
+import nz.cri.gns.NZSHM22.opensha.enumTreeBranches.NZSHM22_FaultModels;
+import nz.cri.gns.NZSHM22.opensha.util.ParameterRunner;
+import nz.cri.gns.NZSHM22.opensha.util.Parameters;
+import nz.cri.gns.NZSHM22.opensha.util.TestHelpers;
+import org.dom4j.DocumentException;
+import org.junit.Test;
+import org.opensha.commons.util.io.archive.ArchiveOutput;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
+
+public class NZSHM22_SubductionInversionRunnerTest {
+
+    // returns a runner that can quickly create a solution
+    public static NZSHM22_SubductionInversionRunner makeRunner()
+            throws DocumentException, IOException {
+        FaultSystemRupSet rupSet =
+                TestHelpers.createRupSet(
+                        NZSHM22_FaultModels.SBD_0_2_HKR_LR_30,
+                        ScalingRelationships.TMG_SUB_2017,
+                        List.of(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9), List.of(4, 5, 6, 10, 11, 12)));
+        ArchiveOutput archiveOutput = new ArchiveOutput.InMemoryZipOutput(true);
+        rupSet.getArchive().write(archiveOutput);
+
+        ParameterRunner parameterRunner =
+                new ParameterRunner(Parameters.NZSHM22.INVERSION_HIKURANGI);
+        NZSHM22_SubductionInversionRunner runner = new NZSHM22_SubductionInversionRunner();
+        parameterRunner.setUpSubductionInversionRunner(runner);
+        // The real deformation model is keyed by the real Hikurangi fault section ids and does
+        // not apply to this synthetic rupture set; leaving it unset makes deformation model
+        // application a no-op (see NZSHM22_InversionFaultSystemRuptSet.applyDeformationModel).
+        runner.deformationModel = null;
+        runner.setIterationCompletionCriteria(100)
+                .setSelectionIterations(1)
+                .setRepeatable(true)
+                .setInversionAveraging(false)
+                .setRuptureSetArchiveInput(archiveOutput.getCompletedInput());
+
+        return runner;
+    }
+
+    @Test
+    public void testRunnerModuleAttachedToSolution() throws DocumentException, IOException {
+        NZSHM22_SubductionInversionRunner runner = makeRunner();
+
+        FaultSystemSolution solution = runner.runInversion();
+        String expectedJson = runner.toJson();
+
+        NZSHM22_InversionRunnerModule module =
+                solution.getModule(NZSHM22_InversionRunnerModule.class);
+        assertNotNull(module);
+        assertTrue(module.getRunner() instanceof NZSHM22_SubductionInversionRunner);
+        assertEquals(expectedJson, module.getRunner().toJson());
+    }
+
+    @Test
+    public void testFromJsonRoundTrip() throws DocumentException, IOException {
+        NZSHM22_SubductionInversionRunner runner = makeRunner();
+        NZSHM22_SubductionInversionRunner fromJson =
+                NZSHM22_SubductionInversionRunner.fromJson(runner.toJson());
+        assertEquals(runner.toJson(), fromJson.toJson());
+    }
+}


### PR DESCRIPTION
closes #495 

For classic inversion, stores crustal and subduction inversion parameters in the solution zip file. 

There's no direct way to run an inversion from a config file yet, but the runners can be created from a json file, making it possible to reproduce an inversion run.